### PR TITLE
testing bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can access your API access credentials from the [Accounts Page](https://www.
 
 ##Usage
 ```javascript
-var Lob = require('Lob');
+var Lob = require('lob');
 Lob = new Lob('YOUR API KEY');
 ```
 

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Lob/Lob-node.git"
+    "url": "https://github.com/lob/lob-node.git"
   },
-  "bugs:": "https://github.com/Lob/Lob-node/issues",
-  "main": "./lib/Lob",
+  "bugs:": "https://github.com/lob/lob-node/issues",
+  "main": "./lib/lob",
   "engines": {
     "node": ">= 0.8.0"
   },


### PR DESCRIPTION
Needed to make lob lowercase  "main": "./lib/Lob", so that it would work with Heroku. On Mac's the capitalization doesn't matter, but heroku runs on linux. Which was having issues with that.
