### PR TITLE
Add an npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+**/.*
+gulpfile.js
+examples/
+test/


### PR DESCRIPTION
Brings the tarball published to npm down from several hundred kb (the test assets add a bunch) to a few kb. 
