### PR TITLE
guard against undefined response body

### DIFF
--- a/lib/resources/jobs.js
+++ b/lib/resources/jobs.js
@@ -77,7 +77,7 @@ Jobs.prototype.create = function (params, done) {
   };
 
   var req = request.post(opts, function (e, r, body) {
-    if (body.errors) {
+    if (body && body.errors) {
       done(body.errors, body);
     } else {
       done(e, body);


### PR DESCRIPTION
In the case of connection timeouts, it is possible for `body` in a callback to be undefined.  This PR adds a guard to prevent an unhandled exception when this occurs.  Details below:

Briefly today, we were getting connection timeouts when using the `jobs.create()` method.  When the eventual timeout occurred, it would result in the following unhandled exception:
```
12:36:27 web.1    | 2015-01-28T17:36:27.661Z - error: [server:24] TypeError: Cannot read property 'errors' of undefined
12:36:27 web.1    |   at Request._callback (/Users/joe/work/realtymaps/map/node_modules/lob/lib/resources/jobs.js:80:13)
12:36:27 web.1    |   at self.callback (/Users/joe/work/realtymaps/map/node_modules/lob/node_modules/request/request.js:373:22)
12:36:27 web.1    |   at Request.emit (events.js:117:20)
12:36:27 web.1    |   at Request.onRequestError (/Users/joe/work/realtymaps/map/node_modules/lob/node_modules/request/request.js:971:8)
12:36:27 web.1    |   at ClientRequest.emit (events.js:95:17)
12:36:27 web.1    |   at CleartextStream.socketCloseListener (http.js:1522:9)
12:36:27 web.1    |   at CleartextStream.emit (events.js:117:20)
12:36:27 web.1    |   at tls.js:693:10
12:36:27 web.1    |   at process._tickCallback (node.js:419:13)
```

From the error message and looking at jobs.js:80, it seems like a straightforward bug and fix.  I'm not sure how to add a spec for this issue though, as I don't see an easy way to mock `request` and force a timeout response / undefined `body`.  If you have suggestions for how to go about that, I'd be happy to add to the PR.