### PR TITLE
Fixing a typo in lob.js

### DIFF
--- a/lib/resources/lob.js
+++ b/lib/resources/lob.js
@@ -37,7 +37,7 @@ var Lob = function (apiKey) {
   }
 
   this.headers = {
-    'user-agent': this.useragent
+    'user-agent': this.userAgent
   };
 
   this.jobs = new Jobs(this);


### PR DESCRIPTION
99% sure this was a typo as useragent (no capital a) was never defined anywhere.