### PR TITLE
Add support for promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ Lob.setVersion('api_version');
 
 For a detailed API reference see [below](#API)
 
+### Using Promises
+The Lob wrapper provides a `.promisify()` helper method which creates
+a promise-friendly version of the wrapper.
+
+Note that calling `.promisify()` returns additional methods with the
+`Async`-suffix attached to the Lob object.
+
+Example:
+```javascript
+var Lob = require('lob')('YOUR API KEY').promisify();
+
+Lob.settings.listAsync({ type: 1 }).then(function (res) {
+  console.log(res.data);
+}).catch(function (e) {
+  console.log(e);
+});
+```
+
 ##API<a name="API"></a>
 - [`Lob.jobs`](#Lob-jobs)
   - [`Lob.jobs.retrieve(String id, Function done)`](#Lob-jobs-retrieve)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ using [pdfkit](http://pdfkit.org/). There is an example provided in the examples
 
 The Lob.com API also supports HTML strings in leiu of a file of the above type. See below for examples of submitting with HTML strings.
 
-For templates and more information regarding HTML, please see the [Lob documentation](https://lob.com/docs/node#html-fonts). 
+For templates and more information regarding HTML, please see the [Lob documentation](https://lob.com/docs/node#html-fonts).
 
 ##Usage<a name="Usage"></a>
 ```javascript
@@ -118,14 +118,14 @@ For a detailed API reference see [below](#API)
 
 ###`Lob.jobs`<a name="Lob-jobs"></a>
 #####`Lob.jobs.retrieve(String id, Function done)`<a name="Lob-jobs-retrieve"></a>
-```
+```javascript
 // Retrieve a particular job JOB_ID = "job_*" (required)
 Lob.jobs.retrieve('job_f6f4c0c3f6338136', function (err, res) {
   console.log(err, res);
 });
 ```
 #####`Lob.jobs.list(Object options, Function done)`<a name="Lob-jobs-list"></a>
-```
+```javascript
 // List Jobs with default offset:0, count:0
 Lob.jobs.list(function (err, data) {
   console.log(err, data);
@@ -137,7 +137,7 @@ Lob.jobs.list({count: 5, offset: 10}, function (err, res) {
 });
 ```
 #####`Lob.jobs.create(Object params, Function done)`<a name="Lob-jobs-create"></a>
-```
+```javascript
 //using ID's you already created
 Lob.jobs.create({
   name: 'Lob Test Job',
@@ -169,7 +169,7 @@ Lob.jobs.create({
 ```
 ###`Lob.addresses`<a name="Lob-addresses"></a>
 #####`Lob.addresses.retrieve(String id, Function done)`<a name="Lob-addresses-retrieve"></a>
-```
+```javascript
 // Retrieve a particular address address object
 //
 Lob.addresses.retrieve('adr_cda562558b71ff93', function (err, res) {
@@ -177,7 +177,7 @@ Lob.addresses.retrieve('adr_cda562558b71ff93', function (err, res) {
 });
 ```
 #####`Lob.addresses.delete(String id, Function done)`<a name="Lob-addresses-delete"></a>
-```
+```javascript
 // Delete an Address Object (make sure it exists first)
 //
 Lob.addresses.delete('adr_71d64099e6729996', function (err, res) {
@@ -185,7 +185,7 @@ Lob.addresses.delete('adr_71d64099e6729996', function (err, res) {
 });
 ```
 #####`Lob.addresses.list(Object options, Function done)`<a name="Lob-addresses-list"></a>
-```
+```javascript
 // List All Addresses with default offset:0, count:0
 //
 Lob.addresses.list(function (err, res) {
@@ -199,7 +199,7 @@ Lob.addresses.list({count: 10, offset: 5}, function (err, res) {
 });
 ```
 #####`Lob.addresses.create(Object params, Function done)`<a name="Lob-addresses-create"></a>
-```
+```javascript
 Lob.addresses.create({
   name: 'Test Name',
   email: 'test@gmail.com',
@@ -216,7 +216,7 @@ Lob.addresses.create({
 ```
 ###`Lob.objects`<a name="Lob-objects"></a>
 #####`Lob.objects.retrieve(String id, Function done)`<a name="Lob-objects-retrieve"></a>
-```
+```javascript
 // Retrieve a particular object OBJECT_ID = "obj_*" (required)
 //
 Lob.objects.retrieve('obj_1d1188df1e8d6427', function (err, res) {
@@ -224,7 +224,7 @@ Lob.objects.retrieve('obj_1d1188df1e8d6427', function (err, res) {
 });
 ```
 #####`Lob.objects.list(Object options, Function done)`<a name="Lob-objects-list"></a>
-```
+```javascript
 // List All Objects with default offset:0, count:0
 //
 Lob.objects.list(function (err, res) {
@@ -238,7 +238,7 @@ Lob.objects.list({count: 10, offset: 5}, function (err, res) {
 });
 ```
 #####`Lob.objects.create(Object params, Function done)`<a name="Lob-objects-create"></a>
-```
+```javascript
 // Creating an Object with local file
 //
 Lob.objects.create({
@@ -270,7 +270,7 @@ Lob.objects.create({
 });
 ```
 #####`Lob.objects.delete(String id, Function done)`<a name="Lob-objects-delete"></a>
-```
+```javascript
 Lob.objects.delete('obj_1d1188df1e8d6427', function (err, res) {
   console.log(err, res);
 });
@@ -283,14 +283,14 @@ Lob.settings.list({ type: 1 }, function (err, res) {
 });
 ```
 #####`Lob.settings.retrieve(String id, Function done)`<a name="Lob-settings-retrieve"></a>
-```
+```javascript
 Lob.settings.retrieve('100', function (err, res) {
   console.log(err, res);
 });
 ```
 ###`Lob.services`<a name="Lob-services"></a>
 #####`Lob.services.retrieve(String id, Function done)`<a name="Lob-services-retrieve"></a>
-```
+```javascript
 // Retrieve a particular service object
 //
 Lob.services.retrieve('2', function (err, res) {
@@ -298,7 +298,7 @@ Lob.services.retrieve('2', function (err, res) {
 });
 ```
 #####`Lob.services.list(Object options, Function done)`<a name="Lob-services-list"></a>
-```
+```javascript
 // List All services
 //
 Lob.services.list(function (err, res) {
@@ -307,7 +307,7 @@ Lob.services.list(function (err, res) {
 ```
 ###`Lob.postcards`<a name="Lob-postcards"></a>
 #####`Lob.postcards.retrieve(String id, Function done)`<a name="Lob-postcards-retrieve"></a>
-```
+```javascript
 // Retrieve a particular postcard object
 //
 Lob.postcards.retrieve('psc_056fdd2b4a11a169', function (err, res) {
@@ -315,7 +315,7 @@ Lob.postcards.retrieve('psc_056fdd2b4a11a169', function (err, res) {
 });
 ```
 #####`Lob.postcards.list(Object options, Function done)`<a name="Lob-postcards-list"></a>
-```
+```javascript
 // List All Postcards with default offset:0, count:0
 //
 Lob.postcards.list(function (err, res) {
@@ -329,7 +329,7 @@ Lob.postcards.list({offset: 10, count: 5}, function (err, res) {
 });
 ```
 #####`Lob.postcards.create(Object params, Function done)`<a name="Lob-postcards-create"></a>
-```
+```javascript
 // Creating PostCard with local file
 //
 Lob.postcards.create({
@@ -367,7 +367,7 @@ Lob.postcards.create({
 ```
 ###`Lob.checks`<a name="Lob-checks"></a>
 #####`Lob.checks.retrieve(String id, Function done)`<a name="Lob-checks-retrieve"></a>
-```
+```javascript
 // Retrieve a particular check object
 //
 Lob.checks.retrieve('psc_056fdd2b4a11a169', function (err, res) {
@@ -375,7 +375,7 @@ Lob.checks.retrieve('psc_056fdd2b4a11a169', function (err, res) {
 });
 ```
 #####`Lob.checks.list(Object options, Function done)`<a name="Lob-checks-list"></a>
-```
+```javascript
 // List All Checks with default offset:0, count:0
 //
 Lob.checks.list(function (err, res) {
@@ -384,7 +384,7 @@ Lob.checks.list(function (err, res) {
 /**/
 ```
 #####`Lob.checks.create(Object params, Function done)`<a name="Lob-checks-create"></a>
-```
+```javascript
 // Creating Check
 /**/
 Lob.checks.create({
@@ -440,7 +440,7 @@ Lob.bankAccounts.create({
 ```
 ###`Lob.bankAccounts`<a name="Lob-bankAccounts"></a>
 #####`Lob.bankAccounts.retrieve(String id, Function done)`<a name="Lob-bankAccounts-retrieve"></a>
-```
+```javascript
 // Retrieve a particular Bank Account Object
 //
 Lob.bankAccounts.retrieve('bank_7a88fa3abe5e2da', function (err, res) {
@@ -448,14 +448,14 @@ Lob.bankAccounts.retrieve('bank_7a88fa3abe5e2da', function (err, res) {
 });
 ```
 #####`Lob.bankAccounts.delete(String id, Function done)`<a name="Lob-bankAccounts-delete"></a>
-```
+```javascript
 // Deleting a bank account
 Lob.bankAccounts.delete('bank_7a88fa3abe5e2da', function (err, res) {
   console.log(err, res);
 });
 ```
 #####`Lob.bankAccounts.list(Object options, Function done)`<a name="Lob-bankAccounts-list"></a>
-```
+```javascript
 // List All Accounts with default offset:0, count:10
 //
 Lob.bankAccounts.list(function (err, res) {
@@ -463,7 +463,7 @@ Lob.bankAccounts.list(function (err, res) {
 });
 ```
 #####`Lob.bankAccounts.create(Object params, Function done)`<a name="Lob-bankAccounts-create"></a>
-```
+```javascript
 // Creating a Bank Account
 //
 Lob.bankAccounts.create({
@@ -492,21 +492,21 @@ Lob.bankAccounts.create({
 ```
 ###`Lob.areas`<a name="Lob-areas"></a>
 #####`Lob.areas.retrieve(String id, Function done)`<a name="Lob-areas-retrieve"></a>
-```
+```javascript
 // Retrieve a particular Area
 Lob.areas.retrieve('area_350e47ace201ee4', function (err, res) {
   console.log(err, res);
 });
 ```
 #####`Lob.areas.list(Object options, Function done)`<a name="Lob-areas-list"></a>
-```
+```javascript
 // List all areas with count: 5 and offset: 10
 Lob.areas.list({count: 5, offset: 10}, function (err, res) {
   console.log(err, res);
 });
 ```
 #####`Lob.areas.create(Object params, Function done)`<a name="Lob-areas-create"></a>
-```
+```javascript
 // Create an area mailing with a mix of local and remote files
 // You can mix and match (for example, both local or both remote)
 Lob.areas.create({
@@ -532,7 +532,7 @@ Lob.areas.create({
 ```
 ###`Lob.routes`<a name="Lob-routes"></a>
 #####`Lob.routes.list(Object options, Function done)`<a name="Lob-routes-list"></a>
-```
+```javascript
 // List all routes for a set of zip codes
 Lob.routes.list({
   zip_codes: ['94108', '94709', '94608']
@@ -542,7 +542,7 @@ Lob.routes.list({
 ```
 ###`Lob.verification`<a name="Lob-verification"></a>
 #####`Lob.verification.verify(Object params, Function done)`<a name="Lob-verification-verify"></a>
-```
+```javascript
 Lob.verification.verify({ // Inline address only
   address_line1: '325 Berry Street',
   address_line2: 'Unit 211',
@@ -556,7 +556,7 @@ Lob.verification.verify({ // Inline address only
 ```
 ###`Lob.countries`<a name="Lob-countries"></a>
 #####`Lob.countries.list(Object options, Function done)`<a name="Lob-countries-list"></a>
-```
+```javascript
 // List All Countries with defaults
 //
 Lob.countries.list(function (err, res) {
@@ -565,7 +565,7 @@ Lob.countries.list(function (err, res) {
 ```
 ###`Lob.states`<a name="Lob-states"></a>
 #####`Lob.states.list(Object options, Function done)`<a name="Lob-states-list"></a>
-```
+```javascript
 Lob.states.list(function (err, res) {
   console.log(err, res);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,10 @@
 // Include gulp
-var gulp = require('gulp');
-var plugins = require('gulp-load-plugins')();
-var argv    = require('yargs').argv;
-var stylish = require('jshint-stylish');
+var gulp       = require('gulp');
+var plugins    = require('gulp-load-plugins')();
+var del        = require('del');
+var argv       = require('yargs').argv;
+var stylish    = require('jshint-stylish');
+var vinylPaths = require('vinyl-paths');
 
 var paths = {
   sourceFiles: 'lib/**/*.js',
@@ -38,7 +40,7 @@ gulp.task('coveralls', function () {
 gulp.task('testCI', ['lint', 'style', 'cover'], function () {
   if (process.env.NODE_ENV !== 'test') {
     gulp.src(process.env.COVERAGE_DIR + '/coverage')
-      .pipe(plugins.clean());
+      .pipe(vinylPaths(del));
     Object.keys(envVars).forEach(function (key) {
       process.env[key] = envVars[key];
     });

--- a/lib/resources/lob.js
+++ b/lib/resources/lob.js
@@ -5,23 +5,19 @@
 // Lob.DEFAULT_BASE_PATH = '/v1/';
 // Lob.DEFAULT_API_VERSION = null;
 
+var Promise = require('bluebird');
 var clientVersion = require('../../package.json').version;
 var userAgent = 'Lob/v1 NodeBindings/' + clientVersion;
 
-var Jobs = require('./jobs');
-var Addresses = require('./addresses');
-var Verification = require('./verification');
-var Countries = require('./countries');
-var States = require('./states');
-var Objects = require('./objects');
-var Settings = require('./settings');
-var Services = require('./services');
-var Packagings = require('./packagings');
-var Postcards = require('./postcards');
-var Checks = require('./checks');
-var BankAccounts = require('./bankAccounts');
-var Areas = require('./areas');
-var Routes = require('./routes');
+var initResources = function () {
+  var i = 0, l = this.resources.length, resource;
+
+  for(; i < l; i++) {
+    resource = this.resources[i];
+    this[resource] = require('./' + resource);
+    this[resource] = new this[resource](this);
+  }
+};
 
 var Lob = function (apiKey) {
   /* istanbul ignore next */
@@ -40,57 +36,45 @@ var Lob = function (apiKey) {
     'user-agent': this.userAgent
   };
 
-  this.jobs = new Jobs(this);
-  this.addresses = new Addresses(this);
-  this.verification = new Verification(this);
-  this.states = new States(this);
-  this.countries = new Countries(this);
-  this.objects = new Objects(this);
-  this.settings = new Settings(this);
-  this.services = new Services(this);
-  this.packagings = new Packagings(this);
-  this.postcards = new Postcards(this);
-  this.checks = new Checks(this);
-  this.bankAccounts = new BankAccounts(this);
-  this.areas = new Areas(this);
-  this.routes = new Routes(this);
+  this.resources = [
+    'jobs',
+    'addresses',
+    'verification',
+    'countries',
+    'states',
+    'objects',
+    'settings',
+    'services',
+    'packagings',
+    'postcards',
+    'checks',
+    'bankAccounts',
+    'areas',
+    'routes'
+  ];
+
+  initResources.call(this);
 };
 
 Lob.prototype.setHost = function (host) {
   this.endpoint = host;
-  this.jobs = new Jobs(this);
-  this.addresses = new Addresses(this);
-  this.verification = new Verification(this);
-  this.states = new States(this);
-  this.countries = new Countries(this);
-  this.objects = new Objects(this);
-  this.settings = new Settings(this);
-  this.services = new Services(this);
-  this.packagings = new Packagings(this);
-  this.postcards = new Postcards(this);
-  this.checks = new Checks(this);
-  this.bankAccounts = new BankAccounts(this);
-  this.areas = new Areas(this);
-  this.routes = new Routes(this);
+  initResources.call(this);
 };
 
 Lob.prototype.setVersion = function (version) {
   this.apiVersion = version;
   this.headers['Lob-Version'] = this.apiVersion;
-  this.jobs = new Jobs(this);
-  this.addresses = new Addresses(this);
-  this.verification = new Verification(this);
-  this.states = new States(this);
-  this.countries = new Countries(this);
-  this.objects = new Objects(this);
-  this.settings = new Settings(this);
-  this.services = new Services(this);
-  this.packagings = new Packagings(this);
-  this.postcards = new Postcards(this);
-  this.checks = new Checks(this);
-  this.bankAccounts = new BankAccounts(this);
-  this.areas = new Areas(this);
-  this.routes = new Routes(this);
+  initResources.call(this);
+};
+
+Lob.prototype.promisify = function () {
+  var self = Promise.promisifyAll(this);
+
+  self.resources.forEach(function (resource) {
+    self[resource] = Promise.promisifyAll(self[resource]);
+  });
+
+  return self;
 };
 
 module.exports = Lob;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "Joshua McGinnis <joshua@mcginnis.io>"
   ],
   "dependencies": {
+    "bluebird": "^2.9.14",
     "coveralls": "^2.11.1",
     "del": "^1.1.1",
     "gulp": "^3.8.6",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "gulp-jshint": "~1.8.2",
     "chai": "^1.9.1",
     "yargs": "^1.3.1",
-    "gulp-load-plugins": "^0.5.3",
     "jshint-stylish": "~0.4.0",
     "mocha": "~1.21.3",
     "gulp-mocha": "~0.5.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "Peter Nagel <peter@lob.com>",
     "Shrav Mehta <shrav@lob.com>",
     "Amrit Ayalur <amrit@lob.com>",
-    "Grayson Chao <grayson@lob.com>"
+    "Grayson Chao <grayson@lob.com>",
+    "Joshua McGinnis <joshua@mcginnis.io>"
   ],
   "dependencies": {
     "coveralls": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
   ],
   "dependencies": {
     "coveralls": "^2.11.1",
+    "del": "^1.1.1",
     "gulp": "^3.8.6",
     "gulp-coveralls": "^0.1.2",
     "gulp-load-plugins": "^0.5.3",
     "mocha-lcov-reporter": "0.0.1",
     "pdfkit": "^0.6.5",
-    "request": "^2.39.0"
+    "request": "^2.39.0",
+    "vinyl-paths": "^1.0.0"
   },
   "devDependencies": {
     "gulp-jshint": "~1.8.2",
@@ -37,13 +39,12 @@
     "yargs": "^1.3.1",
     "jshint-stylish": "~0.4.0",
     "mocha": "~1.21.3",
-    "gulp-mocha": "~0.5.2",
-    "gulp-istanbul": "~0.2.1",
-    "istanbul": "^0.3.0",
+    "gulp-mocha": "~2.0.0",
+    "gulp-istanbul": "~0.6.0",
+    "istanbul": "~0.3.8",
     "gulp-jscs": "^1.0.0",
     "gulp-istanbul-enforcer": "^1.0.3",
     "gulp-exit": "0.0.2",
-    "gulp-clean": "^0.3.1",
     "gulp-util": "^3.0.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "request": "^2.39.0"
   },
   "devDependencies": {
-    "gulp": "~3.8.6",
     "gulp-jshint": "~1.8.2",
     "chai": "^1.9.1",
     "yargs": "^1.3.1",

--- a/test/jobs.js
+++ b/test/jobs.js
@@ -188,7 +188,6 @@ describe('Jobs', function () {
           }
         ]
       }, function (err, res) {
-        console.log(res);
         expect(res.object).to.eql('job');
         expect(res.objects.length).to.eql(2);
         done();

--- a/test/lob.js
+++ b/test/lob.js
@@ -20,6 +20,16 @@ describe('Init', function () {
   });
 });
 
+describe('Promisification', function() {
+  it('should allow you to promisify the wrapper', function () {
+    var Lob = require('../lib')('api_key');
+    expect(Lob.promisify).to.be.a('function');
+
+    Lob = Lob.promisify();
+    expect(Lob.setVersionAsync).to.be.a('function');
+  });
+});
+
 describe('setHost', function () {
   it('should allow you to override the host', function () {
     var lob = require('../lib')('api_key');


### PR DESCRIPTION
Here is an initial take on adding promises to the library. Based on the requirements, you had asked that the existing callback-pattern be supported while also allowing users to use the [bluebird](https://github.com/petkaantonov/bluebird) promise library to make the wrapper promise-friendly.

While a user could do this themselves without much change to the wrapper, it would involve calling [Bluebird's `.promisifyAll()`](https://github.com/petkaantonov/bluebird/blob/master/API.md#promisepromisifyallobject-target--object-options---object) method on both the Lob prototype, and each of the resources (Lob.settings, Lob.addresses, etc) prototypes as well.

In addition, this commit contains a few other small fixes:
* Fix npm warming via removal of the `gulp-clean` dep in lieu of [vinly-paths](https://github.com/sindresorhus/vinyl-paths) + [del](https://github.com/sindresorhus/del) (see: https://github.com/gulpjs/gulp/blob/master/docs/recipes/delete-files-folder.md)
* Add a resource init method to keep [lib/resources/lob.js](lob/lob-node/blob/master/lib/resources/lob.js) DRY
* Add js syntax highlighting to resource documentation in readme
* Add promisification usage info to readme

Re: testing. I added a test for .promisify(), but I did *not* write a suite of tests for the promise-based version. I'm happy to do if there is consensus on the approach above.
