### PR TITLE
PR #115 Fixes / Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ var Lob = require('lob')('YOUR API KEY');
 var options = {/* see options below */};
 var Lob = require('lob')('YOUR API KEY', options);
 
+// you can also just pass options
+var options = { apiKey: 'foo', host: 'bar' };
+var Lob = require('lob')(options);
+
 // callback pattern
 Lob.settings.list({ type: 1 }, function(err, body) {
   if(err) return callback(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,11 @@ var Lob = function(apiKey, options) {
     return new Lob(apiKey, options);
   }
 
+  if(apiKey && typeof apiKey === 'object') {
+    options = apiKey;
+    apiKey = null;
+  }
+
   this.options = {
     apiKey:    apiKey,
     host:      LOB_HOST,

--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var fs = require('fs'), files = fs.readdirSync('./lib/resources');
+var fs = require('fs'), files = fs.readdirSync(__dirname);
 var resources = {}, resource, i = 0, l = files.length;
 
 for(; i < l; i++) {

--- a/test/index.js
+++ b/test/index.js
@@ -23,6 +23,14 @@ describe('Main Lob Object', function() {
     expect(Lob.options.host).to.eql('http://test');
   });
 
+  it('should allow you to only pass options as first arg', function() {
+    var options = { apiKey: API_KEY, host: 'http://test' };
+    var Lob = require('../lib')(options);
+
+    expect(Lob.options.apiKey).to.eql(API_KEY);
+    expect(Lob.options.host).to.eql('http://test');
+  });
+
   it('should propogate request errors', function(done) {
     var options = { baseURI: 'http://test' };
     var Lob = require('../lib')(API_KEY, options);


### PR DESCRIPTION
As I begin to work on the internal wrapper, I noticed a bug in the resource loader and opportunity to improve the constructor interface slightly.

You can see the fix for the path issue here: ced746b51521941263720a32e547a1ef69718ccc

I also thought that it may be useful to just allow users to optionally pass an options argument to the Lob constructor which may contain the apiKey instead of always reserving the first arg for the key only.

An example:
```javascript
var Lob = require('lob')({ apiKey: 'foo', host: 'bar' });
```