### PR TITLE
clean up package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,23 +24,22 @@
   ],
   "dependencies": {
     "bluebird": "^2.9.24",
-    "coveralls": "^2.11.2",
-    "del": "^1.1.1",
-    "gulp": "^3.8.11",
-    "gulp-coveralls": "^0.1.3",
-    "gulp-load-plugins": "^0.10.0",
-    "mocha-lcov-reporter": "0.0.2",
-    "request": "^2.55.0",
-    "vinyl-paths": "^1.0.0"
+    "request": "^2.55.0"
   },
   "devDependencies": {
     "chai": "^2.2.0",
+    "coveralls": "^2.11.2",
     "csv-parse": "^0.1.1",
+    "del": "^1.1.1",
+    "gulp": "^3.8.11",
+    "gulp-coveralls": "^0.1.3",
     "gulp-exit": "0.0.2",
     "gulp-istanbul": "~0.8.1",
     "gulp-istanbul-enforcer": "^1.0.3",
     "gulp-jscs": "^1.6.0",
     "gulp-jshint": "~1.10.0",
+    "gulp-load-plugins": "^0.10.0",
+    "mocha-lcov-reporter": "0.0.2",
     "gulp-mocha": "~2.0.1",
     "gulp-util": "^3.0.4",
     "istanbul": "~0.3.13",
@@ -48,7 +47,8 @@
     "json-2-csv": "^1.3.0",
     "mocha": "~2.2.4",
     "moment": "^2.10.3",
-    "yargs": "^3.7.2"
+    "yargs": "^3.7.2",
+    "vinyl-paths": "^1.0.0"
   },
   "repository": {
     "type": "git",
@@ -65,5 +65,9 @@
     "lint": "gulp lint",
     "style": "gulp style",
     "coveralls": "gulp coveralls"
-  }
+  },
+  "files": [
+    "lib",
+    "LICENSE.txt"
+  ]
 }


### PR DESCRIPTION
Cleans up package.json so that installing from NPM only includes the necessary node modules for running lob-node, and the necessary files of lob-node (e.g. not test files).