### PR TITLE
fix(errors): reject 500+ errors

### DIFF
--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -66,6 +66,13 @@ var ResourceBase = function (endpoint, config) {
           return reject(body.error);
         }
 
+        if (resp && resp.statusCode >= 500) {
+          var error = new Error(resp.statusMessage + ' (' + resp.statusCode + ')');
+          error.statusCode = resp.statusCode;
+          error.statusMessage = resp.statusMessage;
+          return reject(error);
+        }
+
         return resolve(body);
       });
     }).nodeify(callback);

--- a/test/resourceBase.js
+++ b/test/resourceBase.js
@@ -1,0 +1,22 @@
+var chai    = require('chai');
+var expect  = chai.expect;
+
+var API_KEY = 'test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc';
+var util         = require('util');
+var ResourceBase = require('../lib/resources/resourceBase.js');
+
+describe('ResourceBase', function () {
+  it('should get 504 on gateway timeout', function (done) {
+    var resource = new ResourceBase('', {
+      options: {
+        host: 'http://mock.codes/504',
+        apiKey: API_KEY,
+      }
+    });
+
+    return resource._transmit('GET', null, null, null, function (err, result) {
+      expect(err.statusCode).to.eql(504);
+      return done();
+    });
+  });
+});


### PR DESCRIPTION
### What

Ensures that 500+ errors get rejected

### Why

Currently it does not reject 500+ errors

@robinjoseph08 @elnaz @mgartner 