### PR TITLE
fix(tests): replace file with check_bottom for checks

### DIFF
--- a/test/checks.js
+++ b/test/checks.js
@@ -17,7 +17,7 @@ describe('Checks', function () {
         from: 'adr_8613108bcfa00806',
         amount: 100,
         memo: 'test check',
-        file: '<h1>Test Check</h1>'
+        check_bottom: '<h1>Test Check</h1>'
       }, function (err, res) {
         expect(res).to.have.property('id');
         expect(res).to.have.property('description');


### PR DESCRIPTION
### What

Replace `file` with `check_bottom` for checks in the tests

### Why

The new version calls for it.

@brianseitel 