### PR TITLE
fix(readme): update testing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Code changes are welcome and should follow the guidelines below.
 
 * Fork the repository on GitHub.
 * Add tests for your new code ensuring that you have 100% code coverage (we can help you reach 100% but will not merge without it).
-    * Run `gulp cover` to generate a report of test coverage
+    * Run `npm test` to generate a report of the test coverage
 * [Pull requests](http://help.github.com/send-pull-requests/) should be made to the [master branch](https://github.com/Lob/Lob-node/tree/master).
 
 To help encourage consistent code style guidelines, we have included an `.editorconfig` file for use with your favorite [editor](http://editorconfig.org/#download).

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ npm install
 var Lob = require('lob')('YOUR API KEY');
 
 // change api version
-var Lob = require('lob')('YOUR API KEY');
+var Lob = require('lob')('YOUR API KEY', { apiVersion: 'API-VERSION' });
 
 // change internal defaults (e.g. host)
 var options = {/* see options below */};
@@ -171,11 +171,11 @@ To contribute, please see the [CONTRIBUTING.md](https://github.com/lob/lob-node/
 
 To run the tests with coverage:
 
-    gulp testCI
+    npm test
 
 To run the tests without coverage:
 
-    gulp test
+    npm run test-no-cover
 
 =======================
 


### PR DESCRIPTION
### What
 - Update README testing instructions to include npm style scripts instead of gulp (no longer used)
 - Fixes example of how to set custom API version