### PR TITLE
feat(bank-accounts): standardize verify function

### DIFF
--- a/lib/resources/bankAccounts.js
+++ b/lib/resources/bankAccounts.js
@@ -33,8 +33,7 @@ util.inherits(BankAccounts, ResourceBase);
     return this._transmit('POST', null, null, params, callback);
   };
 
-  this.verify = function (id, amounts, callback) {
-    var params = { amounts: amounts };
+  this.verify = function (id, params, callback) {
     return this._transmit('POST', id + '/verify', null, params, callback);
   };
 

--- a/test/bankAccounts.js
+++ b/test/bankAccounts.js
@@ -168,7 +168,7 @@ describe('Bank Accounts', function () {
         signatory: 'John Doe'
       }, function (err, res) {
         var id = res.id;
-        Lob.bankAccounts.verify(id, amounts, function (err, res) {
+        Lob.bankAccounts.verify(id, { amounts: amounts }, function (err, res) {
           expect(res).to.have.property('id');
           expect(res).to.have.property('routing_number');
           expect(res.routing_number).to.eql(routingNumber);
@@ -182,7 +182,7 @@ describe('Bank Accounts', function () {
     });
 
     it('should error on bad bank_account', function (done) {
-      Lob.bankAccounts.verify('38472', [23, 34], function (err) {
+      Lob.bankAccounts.verify('38472', { amounts: [23, 34] }, function (err) {
         expect(err).to.exist;
         return done();
       });


### PR DESCRIPTION
Most of the wrapper functions use a `params` object but verify had an explicit `amounts` argument. I changed the function to be more consistent with everything else we do, even though explicit arguments would arguably be preferred.  

Fixes https://github.com/lob/lob-node/issues/160