### PR TITLE
feat(version): support Node versions 0.12, 4, 5, and 6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 sudo: false
 node_js:
 - '0.10'
+- '0.12'
+- '4'
+- '5'
+- '6'
 after_script:
 - npm run lint
 - npm run enforce


### PR DESCRIPTION
What: Test more recent version of Node.js.

Why: We should be sure that our wrapper works with common versions of Node.js that other developers might be running.