### PR TITLE
Enable Bluebird longStackTraces

### DIFF
--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -4,6 +4,10 @@ var stream    = require('stream');
 var request   = require('request');
 var BBPromise = require('bluebird');
 
+BBPromise.config({
+  longStackTraces: true
+})
+
 var ResourceBase = function (endpoint, config) {
   this.uri    = config.options.host + endpoint;
   this.config = config.options;


### PR DESCRIPTION
This makes stack traces that look like this: 

```
Error: The address you entered was found but more information is needed (such as an apartment, suite, or box number) to match to a specific address.)
    at address.js:38:11
    at tryCatcher (/Users/grant/Sites/instasnail/aws.instasnail/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/grant/Sites/instasnail/aws.instasnail/node_modules/bluebird/js/release/promise.js:502:31)
    at Promise._settlePromise (/Users/grant/Sites/instasnail/aws.instasnail/node_modules/bluebird/js/release/promise.js:559:18)
    at Promise._settlePromise0 (/Users/grant/Sites/instasnail/aws.instasnail/node_modules/bluebird/js/release/promise.js:604:10)
    at Promise._settlePromises (/Users/grant/Sites/instasnail/aws.instasnail/node_modules/bluebird/js/release/promise.js:679:18)
    at Async._drainQueue (/Users/grant/Sites/instasnail/aws.instasnail/node_modules/bluebird/js/release/async.js:138:16)
    at Async._drainQueues (/Users/grant/Sites/instasnail/aws.instasnail/node_modules/bluebird/js/release/async.js:148:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/Users/grant/Sites/instasnail/aws.instasnail/node_modules/bluebird/js/release/async.js:17:14)
    at tryOnImmediate (timers.js:534:15)
    at processImmediate [as _immediateCallback] (timers.js:514:5)
```

look more like this:

```
Error: The address you entered was found but more information is needed (such as an apartment, suite, or box number) to match to a specific address.)
    at address.js:38:11
    at tryOnImmediate (timers.js:534:15)
    at processImmediate [as _immediateCallback] (timers.js:514:5)
From previous event:
    at verify (address.js:17:10)
    at address.js:47:19
    at run (/usr/local/lib/node_modules/babel-cli/node_modules/core-js/modules/es6.promise.js:104:47)
    at /usr/local/lib/node_modules/babel-cli/node_modules/core-js/modules/es6.promise.js:115:28
    at flush (/usr/local/lib/node_modules/babel-cli/node_modules/core-js/modules/$.microtask.js:19:5)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```