### PR TITLE
chore(fix hyperlink): changed out-of-date link to valid

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Code changes are welcome and should follow the guidelines below.
 * Fork the repository on GitHub.
 * Add tests for your new code ensuring that you have 100% code coverage (we can help you reach 100% but will not merge without it).
     * Run `npm test` to generate a report of the test coverage
-* [Pull requests](http://help.github.com/send-pull-requests/) should be made to the [master branch](https://github.com/Lob/Lob-node/tree/master).
+* [Pull requests](https://help.github.com/articles/about-pull-requests/) should be made to the [master branch](https://github.com/lob/lob-node/tree/master).
 
 To help encourage consistent code style guidelines, we have included an `.editorconfig` file for use with your favorite [editor](http://editorconfig.org/#download).
 


### PR DESCRIPTION
What: Fixed old hyperlink that no longer went anywhere to valid one.
Why: Customer facing, so an out of date link is a bad look.