### PR TITLE
feat(delete): Add delete method to postcards, letters, and checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ node_modules
 .DS_Store
 
 coverage
+
+*.sublime-*

--- a/lib/resources/checks.js
+++ b/lib/resources/checks.js
@@ -21,6 +21,10 @@ util.inherits(Checks, ResourceBase);
     return this._transmit('GET', null, options, null, callback);
   };
 
+  this.delete = function (id, callback) {
+    return this._transmit('DELETE', id, null, null, callback);
+  };
+
   this.retrieve = function (id, callback) {
     return this._transmit('GET', id, null, null, callback);
   };

--- a/lib/resources/letters.js
+++ b/lib/resources/letters.js
@@ -25,6 +25,10 @@ util.inherits(Letters, ResourceBase);
     return this._transmit('GET', id, null, null, callback);
   };
 
+  this.delete = function (id, callback) {
+    return this._transmit('DELETE', id, null, null, callback);
+  };
+
   this.create = function (params, callback) {
 
     var isBuffer;

--- a/lib/resources/postcards.js
+++ b/lib/resources/postcards.js
@@ -25,6 +25,10 @@ util.inherits(Postcards, ResourceBase);
     return this._transmit('GET', id, null, null, callback);
   };
 
+  this.delete = function (id, callback) {
+    return this._transmit('DELETE', id, null, null, callback);
+  };
+
   this.create = function (params, callback) {
 
     var isBuffer;

--- a/test/checks.js
+++ b/test/checks.js
@@ -71,4 +71,17 @@ describe('checks', function () {
 
   });
 
+  describe('delete', function () {
+
+    it('deletes a check', function (done) {
+      Lob.checks.create(CHECK, function (err, res) {
+        Lob.checks.delete(res.id, function (err2, res2) {
+          expect(res2.deleted).to.eql(true);
+          return done();
+        });
+      });
+    });
+    
+  });
+
 });

--- a/test/letters.js
+++ b/test/letters.js
@@ -103,4 +103,25 @@ describe('letters', function () {
 
   });
 
+  describe('delete', function () {
+
+    it('deletes a letter', function (done) {
+      var filePath = __dirname + '/assets/8.5x11.pdf';
+      
+      Lob.letters.create({
+        description: 'Test Letter',
+        to: ADDRESS,
+        from: ADDRESS,
+        file: fs.createReadStream(filePath),
+        color: true
+      }, function (err, res) {
+        Lob.letters.delete(res.id, function (err2, res2) {
+          expect(res2.deleted).to.eql(true);
+          return done();
+        });
+      });
+    });
+    
+  });
+
 });

--- a/test/postcards.js
+++ b/test/postcards.js
@@ -112,4 +112,24 @@ describe('postcards', function () {
 
   });
 
+  describe('delete', function () {
+
+    it('deletes a postcard', function (done) {
+      var file = fs.readFileSync(__dirname + '/assets/4_25x6_25.pdf');
+      
+      Lob.postcards.create({
+        description: 'Test Postcard',
+        to: ADDRESS,
+        front: file,
+        back: file
+      }, function (err, res) {
+        Lob.postcards.delete(res.id, function (err2, res2) {
+          expect(res2.deleted).to.eql(true);
+          return done();
+        });
+      });
+    });
+    
+  });
+
 });


### PR DESCRIPTION
Adds `delete()` method to: `/letters`, `/postcards`, and `/checks` resources

Example useage:
```
Lob.postcards.delete('psc_xxxxxxxxxx', function (err, res) {
  if (err) { return console.log(err.message); }
  console.log('Postcard Deleted! ' + res.id);
 });
```

One integration test of the delete method on each `/letters`, `/postcards`, and `/checks` resource