### PR TITLE
chore(examples): Fix examples to use new us_verifications endpoint

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ cd examples/
 
 ### Create letters from CSV
 
-An example showing how to validate and clean addresses from a CSV spreadsheet full of mailing addresses using Lob's [Address Verification API](https://lob.com/verification/address) and then using the clean, valid addresses to dynamically create sample billing letters with variable data using Lob's [Letter API](https://lob.com/services/letters).
+An example showing how to validate and clean addresses from a CSV spreadsheet full of mailing addresses using Lob's [US Address Verification API](https://lob.com/services/verifications) and then using the clean, valid addresses to dynamically create sample billing letters with variable data using Lob's [Letter API](https://lob.com/services/letters).
 
 In order to run the program enter:
 

--- a/examples/verify_and_create_letters_from_csv/index.js
+++ b/examples/verify_and_create_letters_from_csv/index.js
@@ -33,25 +33,25 @@ var parser = parse({ columns: true }, function (err, data) {
     var name = client.name;
     var amount = parseFloat(client.amount).toFixed(2);
     var address = {
-      address_line1: client.address1,
-      address_line2: client.address2,
-      address_city: client.city,
-      address_state: client.state,
-      address_zip: client.zip,
-      address_country: 'US'
+      recipient: name,
+      primary_line: client.primary_line,
+      secondary_line: client.secondary_line,
+      city: client.city,
+      state: client.state,
+      zip_code: client.zip_code
     };
 
-    Lob.verification.verify(address)
+    Lob.usVerifications.verify(address)
     .then(function (verifiedAddress) {
       return Lob.letters.create({
         description: 'Automated Past Due Bill for ' + name,
         to: {
-          name: name,
-          address_line1: verifiedAddress.address.address_line1,
-          address_line2: verifiedAddress.address.address_line12,
-          address_city: verifiedAddress.address.address_city,
-          address_state: verifiedAddress.address.address_state,
-          address_zip: verifiedAddress.address.address_zip,
+          name: verifiedAddress.recipient,
+          address_line1: verifiedAddress.primary_line,
+          address_line2: verifiedAddress.secondary_line,
+          address_city: verifiedAddress.components.city,
+          address_state: verifiedAddress.components.state,
+          address_zip: verifiedAddress.components.zip_code,
           address_country: 'US'
         },
         from: companyInfo,

--- a/examples/verify_and_create_letters_from_csv/input.csv
+++ b/examples/verify_and_create_letters_from_csv/input.csv
@@ -1,4 +1,4 @@
-name,amount,address1,address2,city,state,zip
+name,amount,primary_line,secondary_line,city,state,zip_code
 Kelly Jones,185.54,185 Berry St,,San Francisco,CA,94107
 Margaret Smith,387.45,6575 W Rialto,,fresno,CA,93723
 Jess Smith,19.87,537 Fillmore Street, Apt #2,San Francicso,ca,94117


### PR DESCRIPTION
- [x] Fixes example to use new `us_verifications` endpoint.