### PR TITLE
chore(deprecate): Deprecate support for 0.10 and 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- '0.10'
-- '0.12'
 - '4'
 - '5'
 - '6'

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "bugs:": "https://github.com/lob/lob-node/issues",
   "main": "./lib/index",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.0.0"
   },
   "scripts": {
     "test": "NODE_ENV=test istanbul cover _mocha -- test --recursive --timeout 30000",


### PR DESCRIPTION
- [x] Remove support for node 0.10 and 0.12, since those were [deprecated](https://github.com/nodejs/Release#release-schedule1) at the end of last year.