### PR TITLE
refactor(object): Use Object.prototype.hasOwnProperty.call, instead of assuming objects inherit from Object.prototype

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ var Lob = function (apiKey, options) {
 
   if (options && typeof options === 'object') {
 
-    if (options.hasOwnProperty('apiVersion')) {
+    if (Object.prototype.hasOwnProperty.call(options, 'apiVersion')) {
       this.options.headers['Lob-Version'] = options.apiVersion;
     }
 

--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -49,7 +49,7 @@ var ResourceBase = function (endpoint, config) {
         break;
       }
 
-      if (val !== undefined && val !== null && val.hasOwnProperty('value')) {
+      if (val !== undefined && val !== null && Object.prototype.hasOwnProperty.call(val, 'value')) {
         isMultiPartForm = true;
         break;
       }


### PR DESCRIPTION
Fixes #190 