### PR TITLE
refactor(resources): remove dynamic requires

### DIFF
--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -1,20 +1,14 @@
 'use strict';
 
-var fs        = require('fs');
-var files     = fs.readdirSync(__dirname);
-var resources = {};
-
-for (var i = 0; i < files.length; i++) {
-  var resource = files[i];
-
-  if (resource === 'index.js' ||
-     resource === 'resourceBase.js' ||
-     resource.indexOf('.js') < 0) {
-    continue;
-  }
-
-  resource = resource.replace('.js', '');
-  resources[resource] = require('./' + resource);
-}
-
-module.exports = resources;
+module.exports = {
+  addresses: require('./addresses'),
+  areas: require('./areas'),
+  bankAccounts: require('./bankAccounts'),
+  checks: require('./checks'),
+  intlVerifications: require('./intlVerifications'),
+  letters: require('./letters'),
+  postcards: require('./postcards'),
+  routes: require('./routes'),
+  usVerifications: require('./usVerifications'),
+  usZipLookups: require('./usZipLookups')
+};


### PR DESCRIPTION
When bundling with webpack, the proper context for the dynamic requires is lost. This change specifically defines the `module.exports` in order for webpack to correctly bundle everything.