### PR TITLE
feat(us-verifications): allow passing queries in verification creation

### DIFF
--- a/lib/resources/usVerifications.js
+++ b/lib/resources/usVerifications.js
@@ -8,8 +8,13 @@ class USVerifications extends ResourceBase {
     super('us_verifications', config);
   }
 
-  verify (params, callback) {
-    return this._transmit('POST', null, null, params, callback);
+  verify (params, qs, callback) {
+    if (typeof qs === 'function') {
+      callback = qs;
+      qs = {};
+    }
+
+    return this._transmit('POST', null, qs, params, null, callback);
   };
 
 };

--- a/test/usVerifications.js
+++ b/test/usVerifications.js
@@ -6,12 +6,27 @@ describe('us_verifications', () => {
 
     it('verifies an address', (done) => {
       Lob.usVerifications.verify({
-        primary_line: '185 Berry St Ste 6600',
+        primary_line: 'deliverable',
         city: 'San Francisco',
         state: 'CA',
         zip_code: '94107'
       }, (err, res) => {
-        expect(res.primary_line).to.eql('185 BERRY ST STE 6600');
+        expect(res.primary_line).to.eql('1 TELEGRAPH HILL BLVD');
+        expect(res.deliverability).to.eql('deliverable');
+        return done();
+      });
+    });
+
+    it('verifies an address with custom case', (done) => {
+      Lob.usVerifications.verify({
+        primary_line: 'deliverable',
+        city: 'San Francisco',
+        state: 'CA',
+        zip_code: '94107'
+      }, {
+        case: 'proper'
+      }, (err, res) => {
+        expect(res.primary_line).to.eql('1 Telegraph Hill Blvd');
         expect(res.deliverability).to.eql('deliverable');
         return done();
       });


### PR DESCRIPTION
**What**
- [x] Allow a `qs` object to be passed in when creating a US Verification

**Notes**
The old function signature (of arity 2) is still valid.