### PR TITLE
fix(headers): don't save request specific headers in configs

### DIFF
--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -20,15 +20,13 @@ class ResourceBase {
       headers = headers || {};
     }
 
-    for (let headerKey in headers) {
-      this.config.headers[headerKey] = headers[headerKey];
-    }
+    const allHeaders = Object.assign({}, this.config.headers, headers);
 
     const opts = {
       url: `${this.uri}${uri ? `/${uri}` : ''}`,
       method: method,
       auth: { user: this.config.apiKey, password: '' },
-      headers: this.config.headers,
+      headers: allHeaders,
       json: true
     };
 


### PR DESCRIPTION
## What 
- [x] Don't save request-specific headers in `this.configs.headers`

## Why
`this.configs.headers` is used throughout all request executions. By saving these values in `this.configs.headers` we will persist headers meant for a particular request to future requests. This is particularly bad if someone is sendings resource with and without idemptoency keys as the later ones won't be created.