### PR TITLE
fix(resource-base): default body to empty object

### DIFF
--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -66,7 +66,7 @@ class ResourceBase {
 
     return new Bluebird (function (resolve, reject) {
       Request(opts, function (err, resp, body) {
-        body = Object.assign({}, body);
+        body = body || {}
 
         /* istanbul ignore next */
         if (err) {

--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -66,6 +66,7 @@ class ResourceBase {
 
     return new Bluebird (function (resolve, reject) {
       Request(opts, function (err, resp, body) {
+        body = Object.assign({}, body);
 
         /* istanbul ignore next */
         if (err) {


### PR DESCRIPTION
## What
- [x] Defaults response body to an empty object

## Why
If an endpoint does not contain a body (ex. a 204 response) then currently the library will fail at [this step](https://github.com/lob/lob-node/blob/master/lib/resources/resourceBase.js#L89-L93) as it attempts to set the `_response` property on a non-existent body. The error thrown is `Object.defineProperty called on non-object`.