### PR TITLE
handle undefined multipart form value

### DIFF
--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -33,6 +33,9 @@ class ResourceBase {
     let isMultiPartForm = false;
 
     for (let key in form) {
+      if (form[key] === undefined) {
+        delete form[key];
+      }
       if (form[key] === true || form[key] === false) {
         form[key] = form[key].toString();
       }

--- a/test/letters.js
+++ b/test/letters.js
@@ -90,6 +90,23 @@ describe('letters', () => {
       });
     });
 
+    it('creates a letter with undefined optional parameters', (done) => {
+      const filePath = `${__dirname}/assets/8.5x11.pdf`;
+
+      Lob.letters.create({
+        description: 'Test Letter',
+        to: ADDRESS,
+        from: ADDRESS,
+        file: Fs.createReadStream(filePath),
+        color: false,
+        extra_service: undefined
+      }, (err, res) => {
+        expect(res.object).to.eql('letter');
+        done();
+      });
+
+    });
+
     it('errors with a missing file', (done) => {
       Lob.letters.create({
         description: 'Test Letter',


### PR DESCRIPTION
Undefined values passed into lob.letters.create causes a confusing
exception in the form-data module that request uses for multipart headers

For instance, if the `color` key is set with no value, we get back this
confusing error: `Error: Cannot read property 'name' of undefined`

Now we get `Error: color is undefined`