### PR TITLE
Fixed npm scripts on windows, moved from istanbul to nyc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
-  extends: "eslint-config-lob",
-  globals: {
+  "extends": "eslint-config-lob",
+  "globals": {
     "API_KEY": false,
     "expect": false,
     "Lob": false

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ node_modules
 .DS_Store
 
 coverage
+.nyc_output
 
 *.sublime-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
 - 10
 - 8
 - 6
-- 5
 after_script:
 - npm run lint
 - npm run enforce

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
 sudo: false
 node_js:
-- '4'
-- '5'
-- '6'
+- "node"
+- 10
+- 8
+- 6
+- 5
 after_script:
 - npm run lint
 - npm run enforce

--- a/examples/.eslintrc
+++ b/examples/.eslintrc
@@ -1,5 +1,5 @@
 {
-  rules: {
-    no-console: 0
+  "rules": {
+    "no-console": 0
   }
 }

--- a/examples/create_check.js
+++ b/examples/create_check.js
@@ -6,8 +6,8 @@
  * Run me! This example works out of the box, "batteries included".
  */
 
-var lobFactory = require('../lib/index.js');
-var Lob = new lobFactory('YOUR_API_KEY');
+const lobFactory = require('../lib/index.js');
+const Lob = new lobFactory('YOUR_API_KEY');
 
 // Create the address
 Lob.addresses.create({
@@ -20,7 +20,7 @@ Lob.addresses.create({
   address_state: 'IL',
   address_zip: '60012',
   address_country: 'US'
-}, function (err, address) {
+}, (err, address) => {
   if (err) {
     return console.log(err);
   }
@@ -29,11 +29,11 @@ Lob.addresses.create({
     account_number: '123456789',
     account_type: 'company',
     signatory: 'John Doe'
-  }, function (err, bankAccount) {
+  }, (err, bankAccount) => {
     if (err) {
       return console.log(err);
     }
-    Lob.bankAccounts.verify(bankAccount.id, { amounts: [23, 34] }, function (err) {
+    Lob.bankAccounts.verify(bankAccount.id, { amounts: [23, 34] }, (err) => {
       if (err) {
         return console.log(err);
       }
@@ -54,7 +54,7 @@ Lob.addresses.create({
         memo: 'This is my first Check',
         message: 'This check is for laundry',
         logo: 'https://s3-us-west-2.amazonaws.com/public.lob.com/assets/check_logo.png'
-      }, function (err, check) {
+      }, (err, check) => {
         if (err) {
           return console.log(err);
         }

--- a/examples/create_letter.js
+++ b/examples/create_letter.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const lobFactory = require('../lib/index.js');
 const Lob = new lobFactory('YOUR_API_KEY');
 
-const file = fs.readFileSync(`${__dirname  }/html/letter.html`).toString();
+const file = fs.readFileSync(`${__dirname}/html/letter.html`).toString();
 
 // Create the address
 Lob.addresses.create({

--- a/examples/create_letter.js
+++ b/examples/create_letter.js
@@ -5,12 +5,12 @@
  * Run me! This example works out of the box, "batteries included".
  */
 
-var fs = require('fs');
+const fs = require('fs');
 
-var lobFactory = require('../lib/index.js');
-var Lob = new lobFactory('YOUR_API_KEY');
+const lobFactory = require('../lib/index.js');
+const Lob = new lobFactory('YOUR_API_KEY');
 
-var file = fs.readFileSync(__dirname + '/html/letter.html').toString();
+const file = fs.readFileSync(`${__dirname  }/html/letter.html`).toString();
 
 // Create the address
 Lob.addresses.create({
@@ -24,7 +24,7 @@ Lob.addresses.create({
   address_zip: '60012',
   address_country: 'US'
 })
-.then(function (address) {
+.then((address) => {
   return Lob.letters.create({
     description: 'My First Letter',
     to: address.id,
@@ -37,16 +37,16 @@ Lob.addresses.create({
       address_zip: '60012',
       address_country: 'US'
     },
-    file: file,
+    file,
     merge_variables: {
       name: 'Robin'
     },
     color: false
   });
 })
-.then(function (letter) {
+.then((letter) => {
   console.log('The Lob API responded with this letter object: ', letter);
 })
-.catch(function (err) {
+.catch((err) => {
   console.log(err);
 });

--- a/examples/create_postcard.js
+++ b/examples/create_postcard.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const lobFactory = require('../lib/index.js');
 const Lob = new lobFactory('YOUR_API_KEY');
 
-const file = fs.readFileSync(`${__dirname  }/html/card.html`).toString();
+const file = fs.readFileSync(`${__dirname}/html/card.html`).toString();
 
 // Create the address
 Lob.addresses.create({

--- a/examples/create_postcard.js
+++ b/examples/create_postcard.js
@@ -5,12 +5,12 @@
  * Run me! This example works out of the box, "batteries included".
  */
 
-var fs = require('fs');
+const fs = require('fs');
 
-var lobFactory = require('../lib/index.js');
-var Lob = new lobFactory('YOUR_API_KEY');
+const lobFactory = require('../lib/index.js');
+const Lob = new lobFactory('YOUR_API_KEY');
 
-var file = fs.readFileSync(__dirname + '/html/card.html').toString();
+const file = fs.readFileSync(`${__dirname  }/html/card.html`).toString();
 
 // Create the address
 Lob.addresses.create({
@@ -23,7 +23,7 @@ Lob.addresses.create({
   address_state: 'IL',
   address_zip: '60012',
   address_country: 'US'
-}, function (err, address) {
+}, (err, address) => {
   if (err) {
     console.log(err);
   } else {
@@ -35,7 +35,7 @@ Lob.addresses.create({
       merge_variables: {
         name: 'Robin'
       }
-    }, function (err, postcard) {
+    }, (err, postcard) => {
       if (err) {
         console.log(err);
       } else {

--- a/examples/create_postcards_from_csv/index.js
+++ b/examples/create_postcards_from_csv/index.js
@@ -6,9 +6,9 @@ const fs       = require('fs');
 
 const lobFactory = require('../../lib/index.js');
 const Lob        = new lobFactory('YOUR_API_KEY');
-const input      = fs.readFileSync(`${__dirname  }/input.csv`, { encoding: 'utf-8' });
-const frontHtml  = fs.readFileSync(`${__dirname  }/postcard_front.html`, { encoding: 'utf-8' });
-const backHtml   = fs.readFileSync(`${__dirname  }/postcard_back.html`, { encoding: 'utf-8' });
+const input      = fs.readFileSync(`${__dirname}/input.csv`, { encoding: 'utf-8' });
+const frontHtml  = fs.readFileSync(`${__dirname}/postcard_front.html`, { encoding: 'utf-8' });
+const backHtml   = fs.readFileSync(`${__dirname}/postcard_back.html`, { encoding: 'utf-8' });
 
 const CONCURRENCY = 5;
 
@@ -53,7 +53,7 @@ parse(input, (err, rows) => {
       if (err) {
         return console.log(err);
       }
-      console.log(`Postcard to ${  postcard.to.name  } sent! View it here: ${  postcard.url}`);
+      console.log(`Postcard to ${postcard.to.name} sent! View it here: ${postcard.url}`);
     });
   }, { concurrency: CONCURRENCY });
 });

--- a/examples/create_postcards_from_csv/index.js
+++ b/examples/create_postcards_from_csv/index.js
@@ -1,22 +1,22 @@
 'use strict';
 
-var bluebird = require('bluebird')
-var parse    = require('csv-parse');
-var fs       = require('fs');
+const bluebird = require('bluebird');
+const parse    = require('csv-parse');
+const fs       = require('fs');
 
-var lobFactory = require('../../lib/index.js');
-var Lob        = new lobFactory('YOUR_API_KEY');
-var input      = fs.readFileSync(__dirname + '/input.csv', { encoding: 'utf-8' });
-var frontHtml  = fs.readFileSync(__dirname + '/postcard_front.html', { encoding: 'utf-8' });
-var backHtml   = fs.readFileSync(__dirname + '/postcard_back.html', { encoding: 'utf-8' });
+const lobFactory = require('../../lib/index.js');
+const Lob        = new lobFactory('YOUR_API_KEY');
+const input      = fs.readFileSync(`${__dirname  }/input.csv`, { encoding: 'utf-8' });
+const frontHtml  = fs.readFileSync(`${__dirname  }/postcard_front.html`, { encoding: 'utf-8' });
+const backHtml   = fs.readFileSync(`${__dirname  }/postcard_back.html`, { encoding: 'utf-8' });
 
-var CONCURRENCY = 5;
+const CONCURRENCY = 5;
 
-parse(input, function (err, rows) {
+parse(input, (err, rows) => {
   if (err) {
     return console.log(err);
   }
-  bluebird.map(rows, function (row) {
+  bluebird.map(rows, (row) => {
     return Lob.postcards.create({
       to: {
         name: row[5],
@@ -49,11 +49,11 @@ parse(input, function (err, rows) {
         name: row[0],
         campaign_id: 'campaign_234'
       }
-    }, function (err, postcard) {
+    }, (err, postcard) => {
       if (err) {
         return console.log(err);
       }
-      console.log('Postcard to ' + postcard.to.name + ' sent! View it here: ' + postcard.url);
-    })
-  }, { concurrency: CONCURRENCY })
+      console.log(`Postcard to ${  postcard.to.name  } sent! View it here: ${  postcard.url}`);
+    });
+  }, { concurrency: CONCURRENCY });
 });

--- a/examples/verify_and_create_letters_from_csv/index.js
+++ b/examples/verify_and_create_letters_from_csv/index.js
@@ -8,10 +8,10 @@ const parse     = require('csv-parse');
 const LobFactory = require('../../lib/index.js');
 const Lob        = new LobFactory('YOUR_API_KEY');
 
-const inputFile = fs.createReadStream(`${__dirname  }/input.csv`);
-const successFd = fs.openSync(`${__dirname  }/success.csv`, 'w');
-const errorFd = fs.openSync(`${__dirname  }/error.csv`, 'w');
-const letterTemplate = fs.readFileSync(`${__dirname  }/letter_template.html`).toString();
+const inputFile = fs.createReadStream(`${__dirname}/input.csv`);
+const successFd = fs.openSync(`${__dirname}/success.csv`, 'w');
+const errorFd = fs.openSync(`${__dirname}/error.csv`, 'w');
+const letterTemplate = fs.readFileSync(`${__dirname}/letter_template.html`).toString();
 
 const companyInfo = {
   name: 'Deluxe Virgina Realty',
@@ -44,7 +44,7 @@ const parser = parse({ columns: true }, (err, data) => {
     Lob.usVerifications.verify(address)
     .then((verifiedAddress) => {
       return Lob.letters.create({
-        description: `Automated Past Due Bill for ${  name}`,
+        description: `Automated Past Due Bill for ${name}`,
         to: {
           name: verifiedAddress.recipient,
           address_line1: verifiedAddress.primary_line,
@@ -65,7 +65,7 @@ const parser = parse({ columns: true }, (err, data) => {
       });
     })
     .then((letter) => {
-      console.log(`Successfully sent a letter to ${   client.name}`);
+      console.log(`Successfully sent a letter to ${client.name}`);
       client.letter_id = letter.id;
       client.letter_url = letter.url;
       converter.json2csv(client, (err, csv) => {
@@ -76,7 +76,7 @@ const parser = parse({ columns: true }, (err, data) => {
       }, { PREPEND_HEADER: false });
     })
     .catch(() => {
-      console.log(`Could not send letter to ${   client.name}`);
+      console.log(`Could not send letter to ${client.name}`);
       converter.json2csv(client, (err, csv) => {
         if (err) {
           throw err;

--- a/examples/verify_and_create_letters_from_csv/index.js
+++ b/examples/verify_and_create_letters_from_csv/index.js
@@ -1,19 +1,19 @@
 'use strict';
 
-var converter = require('json-2-csv');
-var fs       = require('fs');
-var moment   = require('moment');
-var parse    = require('csv-parse');
+const converter = require('json-2-csv');
+const fs        = require('fs');
+const moment    = require('moment');
+const parse     = require('csv-parse');
 
-var LobFactory = require('../../lib/index.js');
-var Lob        = new LobFactory('YOUR_API_KEY');
+const LobFactory = require('../../lib/index.js');
+const Lob        = new LobFactory('YOUR_API_KEY');
 
-var inputFile = fs.createReadStream(__dirname + '/input.csv');
-var successFd = fs.openSync(__dirname + '/success.csv', 'w');
-var errorFd = fs.openSync(__dirname + '/error.csv', 'w');
-var letterTemplate = fs.readFileSync(__dirname + '/letter_template.html').toString();
+const inputFile = fs.createReadStream(`${__dirname  }/input.csv`);
+const successFd = fs.openSync(`${__dirname  }/success.csv`, 'w');
+const errorFd = fs.openSync(`${__dirname  }/error.csv`, 'w');
+const letterTemplate = fs.readFileSync(`${__dirname  }/letter_template.html`).toString();
 
-var companyInfo = {
+const companyInfo = {
   name: 'Deluxe Virgina Realty',
   address_line1: '185 Berry St.',
   address_line2: 'Ste 170',
@@ -23,16 +23,16 @@ var companyInfo = {
   address_country: 'US'
 };
 
-var parser = parse({ columns: true }, function (err, data) {
+const parser = parse({ columns: true }, (err, data) => {
   if (err) {
     return console.log(err);
   }
 
-  data.forEach(function (client) {
+  data.forEach((client) => {
 
-    var name = client.name;
-    var amount = parseFloat(client.amount).toFixed(2);
-    var address = {
+    const name = client.name;
+    const amount = parseFloat(client.amount).toFixed(2);
+    const address = {
       recipient: name,
       primary_line: client.primary_line,
       secondary_line: client.secondary_line,
@@ -42,9 +42,9 @@ var parser = parse({ columns: true }, function (err, data) {
     };
 
     Lob.usVerifications.verify(address)
-    .then(function (verifiedAddress) {
+    .then((verifiedAddress) => {
       return Lob.letters.create({
-        description: 'Automated Past Due Bill for ' + name,
+        description: `Automated Past Due Bill for ${  name}`,
         to: {
           name: verifiedAddress.recipient,
           address_line1: verifiedAddress.primary_line,
@@ -58,26 +58,26 @@ var parser = parse({ columns: true }, function (err, data) {
         file: letterTemplate,
         merge_variables: {
           date: moment().format('LL'),
-          name: name,
+          name,
           amountDue: amount
         },
         color: true
       });
     })
-    .then(function (letter) {
-      console.log('Successfully sent a letter to ' +  client.name);
+    .then((letter) => {
+      console.log(`Successfully sent a letter to ${   client.name}`);
       client.letter_id = letter.id;
       client.letter_url = letter.url;
-      converter.json2csv(client, function (err, csv) {
+      converter.json2csv(client, (err, csv) => {
         if (err) {
           throw err;
         }
         fs.write(successFd, csv);
       }, { PREPEND_HEADER: false });
     })
-    .catch(function () {
-      console.log('Could not send letter to ' +  client.name);
-      converter.json2csv(client, function (err, csv) {
+    .catch(() => {
+      console.log(`Could not send letter to ${   client.name}`);
+      converter.json2csv(client, (err, csv) => {
         if (err) {
           throw err;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const ClientVersion = require('../package.json').version;
 const Resources     = require('./resources');
 
-const LOB_HOST      = 'https://api.lob.com/v1/';
+const LOB_HOST = 'https://api.lob.com/v1/';
 const LOB_USERAGENT = `Lob/v1 NodeBindings/${ClientVersion}`;
 
 const Lob = function (apiKey, options) {
@@ -20,8 +20,8 @@ const Lob = function (apiKey, options) {
   }
 
   this.options = {
-    apiKey:    apiKey,
-    host:      LOB_HOST,
+    apiKey,
+    host: LOB_HOST,
     userAgent: LOB_USERAGENT,
     headers: { 'user-agent': LOB_USERAGENT }
   };
@@ -32,7 +32,7 @@ const Lob = function (apiKey, options) {
       this.options.headers['Lob-Version'] = options.apiVersion;
     }
 
-    for (var key in options)      {
+    for (const key in options) {
       this.options[key] = options[key];
     }
 
@@ -44,10 +44,10 @@ const Lob = function (apiKey, options) {
 (function () {
 
   this._initResources = function () {
-    var services = Object.keys(Resources);
+    const services = Object.keys(Resources);
 
-    for (var i = 0; i < services.length; i++) {
-      var service = services[i];
+    for (let i = 0; i < services.length; i++) {
+      const service = services[i];
       this[service] = new Resources[service](this);
     }
   };

--- a/lib/resources/addresses.js
+++ b/lib/resources/addresses.js
@@ -11,24 +11,24 @@ class Addresses extends ResourceBase {
   list (options, callback) {
     if (typeof options === 'function') {
       callback = options;
-      options  = {};
+      options = {};
     }
 
     return this._transmit('GET', null, options, null, callback);
-  };
+  }
 
   retrieve (id, callback) {
     return this._transmit('GET', id, null, null, callback);
-  };
+  }
 
   delete (id, callback) {
     return this._transmit('DELETE', id, null, null, callback);
-  };
+  }
 
   create (params, callback) {
     return this._transmit('POST', null, null, params, callback);
-  };
+  }
 
-};
+}
 
 module.exports = Addresses;

--- a/lib/resources/bankAccounts.js
+++ b/lib/resources/bankAccounts.js
@@ -11,28 +11,28 @@ class BankAccounts extends ResourceBase {
   list (options, callback) {
     if (typeof options === 'function') {
       callback = options;
-      options  = {};
+      options = {};
     }
 
     return this._transmit('GET', null, options, null, callback);
-  };
+  }
 
   retrieve (id, callback) {
     return this._transmit('GET', id, null, null, callback);
-  };
+  }
 
   delete (id, callback) {
     return this._transmit('DELETE', id, null, null, callback);
-  };
+  }
 
   create (params, callback) {
     return this._transmit('POST', null, null, params, callback);
-  };
+  }
 
   verify (id, params, callback) {
     return this._transmit('POST', `${id}/verify`, null, params, callback);
-  };
+  }
 
-};
+}
 
 module.exports = BankAccounts;

--- a/lib/resources/checks.js
+++ b/lib/resources/checks.js
@@ -11,24 +11,24 @@ class Checks extends ResourceBase {
   list (options, callback) {
     if (typeof options === 'function') {
       callback = options;
-      options  = {};
+      options = {};
     }
 
     return this._transmit('GET', null, options, null, callback);
-  };
+  }
 
   delete (id, callback) {
     return this._transmit('DELETE', id, null, null, callback);
-  };
+  }
 
   retrieve (id, callback) {
     return this._transmit('GET', id, null, null, callback);
-  };
+  }
 
   create (params, headers, callback) {
     return this._transmit('POST', null, null, params, headers, callback);
-  };
+  }
 
-};
+}
 
 module.exports = Checks;

--- a/lib/resources/intlVerifications.js
+++ b/lib/resources/intlVerifications.js
@@ -10,8 +10,8 @@ class IntlVerifications extends ResourceBase {
 
   verify (params, callback) {
     return this._transmit('POST', null, null, params, callback);
-  };
+  }
 
-};
+}
 
 module.exports = IntlVerifications;

--- a/lib/resources/letters.js
+++ b/lib/resources/letters.js
@@ -12,19 +12,19 @@ class Letters extends ResourceBase {
 
     if (typeof options === 'function') {
       callback = options;
-      options  = {};
+      options = {};
     }
 
     return this._transmit('GET', null, options, null, callback);
-  };
+  }
 
   retrieve (id, callback) {
     return this._transmit('GET', id, null, null, callback);
-  };
+  }
 
   delete (id, callback) {
     return this._transmit('DELETE', id, null, null, callback);
-  };
+  }
 
   create (params, headers, callback) {
 
@@ -41,13 +41,13 @@ class Letters extends ResourceBase {
       }
     }
 
-    for (let p in params) {
+    for (const p in params) {
 
       if (p === 'file' || !(params[p] instanceof Object)) {
         continue;
       }
 
-      for (let key in params[p]) {
+      for (const key in params[p]) {
         params[`${p}[${key}]`] = params[p][key];
       }
 
@@ -55,8 +55,8 @@ class Letters extends ResourceBase {
     }
 
     return this._transmit('POST', null, null, params, headers, callback);
-  };
+  }
 
-};
+}
 
 module.exports = Letters;

--- a/lib/resources/postcards.js
+++ b/lib/resources/postcards.js
@@ -12,19 +12,19 @@ class Postcards extends ResourceBase {
 
     if (typeof options === 'function') {
       callback = options;
-      options  = {};
+      options = {};
     }
 
     return this._transmit('GET', null, options, null, callback);
-  };
+  }
 
   retrieve (id, callback) {
     return this._transmit('GET', id, null, null, callback);
-  };
+  }
 
   delete (id, callback) {
     return this._transmit('DELETE', id, null, null, callback);
-  };
+  }
 
   create (params, headers, callback) {
 
@@ -52,13 +52,13 @@ class Postcards extends ResourceBase {
       }
     }
 
-    for (let p in params) {
+    for (const p in params) {
 
       if (p === 'front' || p === 'back' || !(params[p] instanceof Object)) {
         continue;
       }
 
-      for (let key in params[p]) {
+      for (const key in params[p]) {
         params[`${p}[${key}]`] = params[p][key];
       }
 
@@ -66,8 +66,8 @@ class Postcards extends ResourceBase {
     }
 
     return this._transmit('POST', null, null, params, headers, callback);
-  };
+  }
 
-};
+}
 
 module.exports = Postcards;

--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const Bluebird  = require('bluebird');
-const Request   = require('request');
-const Stream    = require('stream');
+const Bluebird = require('bluebird');
+const Request  = require('request');
+const Stream   = require('stream');
 
 class ResourceBase {
 
-  constructor(endpoint, config) {
-    this.uri    = `${config.options.host}${endpoint}`;
+  constructor (endpoint, config) {
+    this.uri = `${config.options.host}${endpoint}`;
     this.config = config.options;
   }
 
@@ -15,8 +15,7 @@ class ResourceBase {
     if (typeof headers === 'function') {
       callback = headers;
       headers = {};
-    }
-    else {
+    } else {
       headers = headers || {};
     }
 
@@ -24,7 +23,7 @@ class ResourceBase {
 
     const opts = {
       url: `${this.uri}${uri ? `/${uri}` : ''}`,
-      method: method,
+      method,
       auth: { user: this.config.apiKey, password: '' },
       headers: allHeaders,
       json: true
@@ -32,7 +31,7 @@ class ResourceBase {
 
     let isMultiPartForm = false;
 
-    for (let key in form) {
+    for (const key in form) {
       if (form[key] === undefined) {
         delete form[key];
       }
@@ -41,7 +40,7 @@ class ResourceBase {
       }
     }
 
-    for (let param in form) {
+    for (const param in form) {
       const val = form[param];
 
       if (val instanceof Stream.Stream) {
@@ -67,9 +66,9 @@ class ResourceBase {
       }
     }
 
-    return new Bluebird (function (resolve, reject) {
-      Request(opts, function (err, resp, body) {
-        body = body || {}
+    return new Bluebird((resolve, reject) => {
+      Request(opts, (err, resp, body) => {
+        body = body || {};
 
         /* istanbul ignore next */
         if (err) {
@@ -101,6 +100,6 @@ class ResourceBase {
     }).nodeify(callback);
   }
 
-};
+}
 
 module.exports = ResourceBase;

--- a/lib/resources/usAutocompletions.js
+++ b/lib/resources/usAutocompletions.js
@@ -4,14 +4,14 @@ const ResourceBase = require('./resourceBase');
 
 class USAutocompletions extends ResourceBase {
 
-  constructor(config) {
+  constructor (config) {
     super('us_autocompletions', config);
   }
 
-  autocomplete(params, callback) {
+  autocomplete (params, callback) {
     return this._transmit('POST', null, null, params, null, callback);
-  };
+  }
 
-};
+}
 
 module.exports = USAutocompletions;

--- a/lib/resources/usVerifications.js
+++ b/lib/resources/usVerifications.js
@@ -15,8 +15,8 @@ class USVerifications extends ResourceBase {
     }
 
     return this._transmit('POST', null, qs, params, null, callback);
-  };
+  }
 
-};
+}
 
 module.exports = USVerifications;

--- a/lib/resources/usZipLookups.js
+++ b/lib/resources/usZipLookups.js
@@ -10,8 +10,8 @@ class USZipLookups extends ResourceBase {
 
   lookup (params, callback) {
     return this._transmit('POST', null, null, params, callback);
-  };
+  }
 
-};
+}
 
 module.exports = USZipLookups;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1973,12 +1973,6 @@
         }
       }
     },
-    "mocha-lcov-reporter": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-0.0.2.tgz",
-      "integrity": "sha1-rdE60kFYQxVwytpELGFO3F5P65U=",
-      "dev": true
-    },
     "moment": {
       "version": "2.22.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
@@ -2046,6 +2040,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2370,7 +2365,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2454,6 +2450,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2500,7 +2497,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2766,7 +2764,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -634,19 +634,705 @@
       }
     },
     "eslint-config-lob": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-lob/-/eslint-config-lob-3.0.0.tgz",
-      "integrity": "sha512-ANT5ZxbkU6zqG0Jz5I/LNmJMvAVHZ6hL+nGH83cJ9+PE4VWRVyuOekDEIVqa3K3OLqES3YG08wA0vKk0CfsyyQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-lob/-/eslint-config-lob-1.0.1.tgz",
+      "integrity": "sha1-sswtnRMgBV7Ijak+xU+Zgc1LKcw=",
       "dev": true,
-      "requires": {
-        "eslint-plugin-lob": "^1.0.1"
+      "dependencies": {
+        "builtin-modules": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+          "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw="
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        },
+        "camelcase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+          "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
+          "requires": {
+            "camelcase": "^1.0.1",
+            "map-obj": "^1.0.0"
+          }
+        },
+        "conventional-changelog": {
+          "version": "0.0.16",
+          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.16.tgz",
+          "integrity": "sha1-CZftvNEZiC+SDpdhwePWQ9iF0f8=",
+          "requires": {
+            "dateformat": "^1.0.11",
+            "event-stream": "^3.1.7",
+            "github-url-from-git": "^1.4.0",
+            "lodash.assign": "^2.4.1",
+            "lodash.partial": "^3.0.0",
+            "lodash.template": "^3.3.0",
+            "normalize-package-data": "^1.0.3"
+          }
+        },
+        "dateformat": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+          "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
+          "requires": {
+            "get-stdin": "*",
+            "meow": "*"
+          }
+        },
+        "duplexer": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+          "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+        },
+        "error-ex": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+          "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "event-stream": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
+          "integrity": "sha1-PMMQ/rHyjS9isqCF1zap71ZjeLg=",
+          "requires": {
+            "duplexer": "~0.1.1",
+            "from": "~0",
+            "map-stream": "~0.1.0",
+            "pause-stream": "0.0.11",
+            "split": "0.3",
+            "stream-combiner": "~0.0.4",
+            "through": "~2.3.1"
+          }
+        },
+        "find-up": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
+          "integrity": "sha1-3wpUq+69+ZhBaPpVa9GKjyS00Vw=",
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^1.0.0"
+          }
+        },
+        "from": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
+          "integrity": "sha1-72OsIGKsMqz3hi4NQLRLiW8i87w="
+        },
+        "get-stdin": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz",
+          "integrity": "sha1-kqxCH2T2wSoflhLAkvvWYZiSctM="
+        },
+        "github-url-from-git": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
+          "integrity": "sha1-KF5rUggZABveEoZ0cEN55P8D4N4="
+        },
+        "github-url-from-username-repo": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
+          "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo="
+        },
+        "graceful-fs": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+          "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
+        },
+        "hosted-git-info": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+          "integrity": "sha1-2elTsmmIvogJbEbpJklNlgTDAPg="
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-finite": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+          "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-utf8": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+          "integrity": "sha1-uKpUElrmJr/k4765ZfFqicWKETc="
+        },
+        "load-json-file": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
+          "integrity": "sha1-0k4Uvif2imrsD4I2WyPhAUYD/Bk=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^1.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "lodash._arraycopy": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+          "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
+        },
+        "lodash._basebind": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+          "integrity": "sha1-6UC5690nwyfgqNqxtVkWxTQelXU=",
+          "requires": {
+            "lodash._basecreate": "~2.4.1",
+            "lodash._setbinddata": "~2.4.1",
+            "lodash._slice": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
+          }
+        },
+        "lodash._basecopy": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+          "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+        },
+        "lodash._basecreate": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+          "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+          "requires": {
+            "lodash._isnative": "~2.4.1",
+            "lodash.isobject": "~2.4.1",
+            "lodash.noop": "~2.4.1"
+          }
+        },
+        "lodash._basecreatecallback": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+          "integrity": "sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=",
+          "requires": {
+            "lodash._setbinddata": "~2.4.1",
+            "lodash.bind": "~2.4.1",
+            "lodash.identity": "~2.4.1",
+            "lodash.support": "~2.4.1"
+          }
+        },
+        "lodash._basecreatewrapper": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+          "integrity": "sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=",
+          "requires": {
+            "lodash._basecreate": "~2.4.1",
+            "lodash._setbinddata": "~2.4.1",
+            "lodash._slice": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
+          }
+        },
+        "lodash._basetostring": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+        },
+        "lodash._basevalues": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+          "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+        },
+        "lodash._createwrapper": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+          "integrity": "sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=",
+          "requires": {
+            "lodash._basebind": "~2.4.1",
+            "lodash._basecreatewrapper": "~2.4.1",
+            "lodash._slice": "~2.4.1",
+            "lodash.isfunction": "~2.4.1"
+          }
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+        },
+        "lodash._isiterateecall": {
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+          "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+        },
+        "lodash._isnative": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+        },
+        "lodash._objecttypes": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+        },
+        "lodash._replaceholders": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz",
+          "integrity": "sha1-iru3EmxDH37XRPe6rznwi8m9nVg="
+        },
+        "lodash._setbinddata": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+          "integrity": "sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=",
+          "requires": {
+            "lodash._isnative": "~2.4.1",
+            "lodash.noop": "~2.4.1"
+          }
+        },
+        "lodash._shimkeys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+          "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+          "requires": {
+            "lodash._objecttypes": "~2.4.1"
+          }
+        },
+        "lodash._slice": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+          "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8="
+        },
+        "lodash.assign": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
+          "integrity": "sha1-hMOVlt1xGBqXsGUpE6fJZ15Jsao=",
+          "requires": {
+            "lodash._basecreatecallback": "~2.4.1",
+            "lodash._objecttypes": "~2.4.1",
+            "lodash.keys": "~2.4.1"
+          }
+        },
+        "lodash.bind": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+          "integrity": "sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=",
+          "requires": {
+            "lodash._createwrapper": "~2.4.1",
+            "lodash._slice": "~2.4.1"
+          }
+        },
+        "lodash.escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
+          "integrity": "sha1-+ylMmae/tYYDn2bWucJ+2HTLe1E=",
+          "requires": {
+            "lodash._basetostring": "^3.0.0"
+          }
+        },
+        "lodash.identity": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+          "integrity": "sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE="
+        },
+        "lodash.isarguments": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+          "integrity": "sha1-67uITEjSc2akTqb+5X7XtaMqgeA="
+        },
+        "lodash.isarray": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+        },
+        "lodash.isfunction": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+          "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE="
+        },
+        "lodash.isobject": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+          "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+          "requires": {
+            "lodash._objecttypes": "~2.4.1"
+          }
+        },
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "requires": {
+            "lodash._isnative": "~2.4.1",
+            "lodash._shimkeys": "~2.4.1",
+            "lodash.isobject": "~2.4.1"
+          }
+        },
+        "lodash.noop": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+          "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o="
+        },
+        "lodash.partial": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.partial/-/lodash.partial-3.1.1.tgz",
+          "integrity": "sha1-q0pqtuMvA+yxUZBIzbrlAmgAU+U=",
+          "requires": {
+            "lodash._createwrapper": "^3.0.0",
+            "lodash._replaceholders": "^3.0.0",
+            "lodash.restparam": "^3.0.0"
+          },
+          "dependencies": {
+            "lodash._basecreate": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+              "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
+            },
+            "lodash._createwrapper": {
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
+              "integrity": "sha1-bcCVY9Y1wKwYxKsZTZINCd6Om8c=",
+              "requires": {
+                "lodash._arraycopy": "^3.0.0",
+                "lodash._basecreate": "^3.0.0",
+                "lodash._replaceholders": "^3.0.0"
+              }
+            }
+          }
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+        },
+        "lodash.support": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+          "integrity": "sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=",
+          "requires": {
+            "lodash._isnative": "~2.4.1"
+          }
+        },
+        "lodash.template": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+          "requires": {
+            "lodash._basecopy": "^3.0.0",
+            "lodash._basetostring": "^3.0.0",
+            "lodash._basevalues": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0",
+            "lodash._reinterpolate": "^3.0.0",
+            "lodash.escape": "^3.0.0",
+            "lodash.keys": "^3.0.0",
+            "lodash.restparam": "^3.0.0",
+            "lodash.templatesettings": "^3.0.0"
+          },
+          "dependencies": {
+            "lodash.keys": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+              "requires": {
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
+              }
+            }
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
+          "integrity": "sha1-U4Uv2DK5IGBaLrYZGby7+484W7Y=",
+          "requires": {
+            "lodash._reinterpolate": "^3.0.0",
+            "lodash.escape": "^3.0.0"
+          }
+        },
+        "loud-rejection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
+          "integrity": "sha1-19oHN36+jHacmp3/QrImsIXoMkY="
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+        },
+        "map-stream": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+          "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+        },
+        "meow": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.5.0.tgz",
+          "integrity": "sha1-vFpdi1uEjvaqUBWL4FcBgusNXk0=",
+          "requires": {
+            "camelcase-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
+          },
+          "dependencies": {
+            "normalize-package-data": {
+              "version": "2.3.5",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+              "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "normalize-package-data": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
+          "integrity": "sha1-i+lVuJB6+XXxpFhOqLubQUkjEvU=",
+          "requires": {
+            "github-url-from-git": "^1.3.0",
+            "github-url-from-username-repo": "^1.0.0",
+            "semver": "2 || 3 || 4"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "4.3.6",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+            }
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+        },
+        "object-assign": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+          "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
+          "integrity": "sha1-xO/jfX/ceS+aApznkG4JXhafm+E=",
+          "requires": {
+            "pinkie-promise": "^1.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
+          "integrity": "sha1-UbEn1IhBAPWAglbkXUcXFroW9i0=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^1.0.0"
+          }
+        },
+        "pause-stream": {
+          "version": "0.0.11",
+          "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+          "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+          "requires": {
+            "through": "~2.3"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
+        "pinkie": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
+        },
+        "pinkie-promise": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+          "requires": {
+            "pinkie": "^1.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          },
+          "dependencies": {
+            "normalize-package-data": {
+              "version": "2.3.5",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+              "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "redent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+          "requires": {
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
+          }
+        },
+        "repeating": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+          "integrity": "sha1-/SfW0mTRj76/qlZVPde4JTWlA04=",
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "requires": {
+            "spdx-license-ids": "^1.0.2"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+          "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0="
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.1.tgz",
+          "integrity": "sha1-u08u0A1QRzqUn3ozPYTswattSD0=",
+          "requires": {
+            "spdx-exceptions": "^1.0.4",
+            "spdx-license-ids": "^1.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+          "integrity": "sha1-KGlKzfOf4n3kUUP/+B8h9sZtRKw="
+        },
+        "split": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+          "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+          "requires": {
+            "through": "2"
+          }
+        },
+        "stream-combiner": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+          "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+          "requires": {
+            "duplexer": "~0.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+          "requires": {
+            "get-stdin": "^4.0.1"
+          },
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "requires": {
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
+          }
+        }
       }
-    },
-    "eslint-plugin-lob": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-lob/-/eslint-plugin-lob-1.2.0.tgz",
-      "integrity": "sha512-K/DWsoXpyt802f5f5tTwV6ouE/O89bUPd9FPGtUizu6H1c+9Zy68FnGeKJP02QGgmAgbVH/WVCjutsepKNlxKQ==",
-      "dev": true
     },
     "eslint-scope": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,12 +136,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "abbrev": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-      "dev": true
-    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -172,23 +166,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
       "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-      "dev": true
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-escapes": {
@@ -261,12 +238,6 @@
       "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
       "dev": true
     },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -328,28 +299,10 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true,
-      "optional": true
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
     },
     "chai": {
       "version": "2.3.0",
@@ -398,27 +351,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "co": {
       "version": "4.6.0",
@@ -543,13 +475,6 @@
         }
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
-      "optional": true
-    },
     "deep-eql": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
@@ -621,73 +546,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
-    },
-    "escodegen": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-      "dev": true,
-      "requires": {
-        "esprima": "^2.7.1",
-        "estraverse": "^1.9.1",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-          "dev": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-          "dev": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-          "dev": true,
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.4",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "wordwrap": "~1.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
-        }
-      }
     },
     "eslint": {
       "version": "5.5.0",
@@ -821,12 +679,6 @@
         "acorn": "^5.6.0",
         "acorn-jsx": "^4.1.1"
       }
-    },
-    "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -983,19 +835,6 @@
       "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
       "dev": true
     },
-    "glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true,
-      "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
     "globals": {
       "version": "11.7.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
@@ -1044,18 +883,6 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
-      "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -1069,12 +896,6 @@
         "ajv": "^5.3.0",
         "har-schema": "^2.0.0"
       }
-    },
-    "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-      "dev": true
     },
     "he": {
       "version": "1.1.1",
@@ -1150,12 +971,6 @@
         "through": "^2.3.6"
       }
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -1219,45 +1034,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "istanbul": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.0.x",
-        "async": "1.x",
-        "escodegen": "1.8.x",
-        "esprima": "2.7.x",
-        "glob": "^5.0.15",
-        "handlebars": "^4.0.1",
-        "js-yaml": "3.x",
-        "mkdirp": "0.5.x",
-        "nopt": "3.x",
-        "once": "1.x",
-        "resolve": "1.1.x",
-        "supports-color": "^3.1.0",
-        "which": "^1.1.1",
-        "wordwrap": "^1.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
-        }
-      }
     },
     "istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -1367,22 +1143,6 @@
         "verror": "1.10.0"
       }
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
-      "optional": true
-    },
     "lcov-parse": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
@@ -1409,12 +1169,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-      "dev": true
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "mime-db": {
@@ -1568,15 +1322,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
-      }
     },
     "nyc": {
       "version": "13.1.0",
@@ -2741,24 +2486,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        }
-      }
-    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -2870,12 +2597,6 @@
       "integrity": "sha512-g2FAVtR8Uh8GO1Nv5wpxW7VFVwHcCEr4wyA8/MHiRkO8uHoR5ntAA8Uq3P1vvMTX/BeQiRVSpDGLd+Wn5HNOTA==",
       "dev": true
     },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
-    },
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
@@ -2970,12 +2691,6 @@
         "resolve-from": "^1.0.0"
       }
     },
-    "resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
-    },
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
@@ -2990,16 +2705,6 @@
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -3089,15 +2794,6 @@
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0"
-      }
-    },
-    "source-map": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-      "dev": true,
-      "requires": {
-        "amdefine": ">=0.0.4"
       }
     },
     "sprintf-js": {
@@ -3272,34 +2968,6 @@
       "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
       "dev": true
     },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
-    },
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
@@ -3348,19 +3016,6 @@
         "isexe": "^2.0.0"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
-      "optional": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3374,19 +3029,6 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
-      }
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,56 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/generator": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
+      "integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.2",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
     "@babel/highlight": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
@@ -22,6 +72,68 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz",
+      "integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+      "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.2.2",
+        "@babel/types": "^7.2.2"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.2.2",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.2.3",
+        "@babel/types": "^7.2.2",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.2.tgz",
+      "integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "abbrev": {
@@ -377,6 +489,16 @@
         }
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -654,705 +776,19 @@
       }
     },
     "eslint-config-lob": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-lob/-/eslint-config-lob-1.0.1.tgz",
-      "integrity": "sha1-sswtnRMgBV7Ijak+xU+Zgc1LKcw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-lob/-/eslint-config-lob-3.0.0.tgz",
+      "integrity": "sha512-ANT5ZxbkU6zqG0Jz5I/LNmJMvAVHZ6hL+nGH83cJ9+PE4VWRVyuOekDEIVqa3K3OLqES3YG08wA0vKk0CfsyyQ==",
       "dev": true,
-      "dependencies": {
-        "builtin-modules": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
-          "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw="
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-        },
-        "camelcase-keys": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-          "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
-          "requires": {
-            "camelcase": "^1.0.1",
-            "map-obj": "^1.0.0"
-          }
-        },
-        "conventional-changelog": {
-          "version": "0.0.16",
-          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.16.tgz",
-          "integrity": "sha1-CZftvNEZiC+SDpdhwePWQ9iF0f8=",
-          "requires": {
-            "dateformat": "^1.0.11",
-            "event-stream": "^3.1.7",
-            "github-url-from-git": "^1.4.0",
-            "lodash.assign": "^2.4.1",
-            "lodash.partial": "^3.0.0",
-            "lodash.template": "^3.3.0",
-            "normalize-package-data": "^1.0.3"
-          }
-        },
-        "dateformat": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-          "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
-          "requires": {
-            "get-stdin": "*",
-            "meow": "*"
-          }
-        },
-        "duplexer": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-          "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
-        },
-        "error-ex": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-          "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
-          "requires": {
-            "is-arrayish": "^0.2.1"
-          }
-        },
-        "event-stream": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
-          "integrity": "sha1-PMMQ/rHyjS9isqCF1zap71ZjeLg=",
-          "requires": {
-            "duplexer": "~0.1.1",
-            "from": "~0",
-            "map-stream": "~0.1.0",
-            "pause-stream": "0.0.11",
-            "split": "0.3",
-            "stream-combiner": "~0.0.4",
-            "through": "~2.3.1"
-          }
-        },
-        "find-up": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
-          "integrity": "sha1-3wpUq+69+ZhBaPpVa9GKjyS00Vw=",
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^1.0.0"
-          }
-        },
-        "from": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
-          "integrity": "sha1-72OsIGKsMqz3hi4NQLRLiW8i87w="
-        },
-        "get-stdin": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz",
-          "integrity": "sha1-kqxCH2T2wSoflhLAkvvWYZiSctM="
-        },
-        "github-url-from-git": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
-          "integrity": "sha1-KF5rUggZABveEoZ0cEN55P8D4N4="
-        },
-        "github-url-from-username-repo": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
-          "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo="
-        },
-        "graceful-fs": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-          "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
-        },
-        "hosted-git-info": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-          "integrity": "sha1-2elTsmmIvogJbEbpJklNlgTDAPg="
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "requires": {
-            "repeating": "^2.0.0"
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
-        },
-        "is-finite": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-          "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-utf8": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
-          "integrity": "sha1-uKpUElrmJr/k4765ZfFqicWKETc="
-        },
-        "load-json-file": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
-          "integrity": "sha1-0k4Uvif2imrsD4I2WyPhAUYD/Bk=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^1.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "lodash._arraycopy": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-          "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
-        },
-        "lodash._basebind": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
-          "integrity": "sha1-6UC5690nwyfgqNqxtVkWxTQelXU=",
-          "requires": {
-            "lodash._basecreate": "~2.4.1",
-            "lodash._setbinddata": "~2.4.1",
-            "lodash._slice": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
-          }
-        },
-        "lodash._basecopy": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-          "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-        },
-        "lodash._basecreate": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-          "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
-          "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash.isobject": "~2.4.1",
-            "lodash.noop": "~2.4.1"
-          }
-        },
-        "lodash._basecreatecallback": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
-          "integrity": "sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=",
-          "requires": {
-            "lodash._setbinddata": "~2.4.1",
-            "lodash.bind": "~2.4.1",
-            "lodash.identity": "~2.4.1",
-            "lodash.support": "~2.4.1"
-          }
-        },
-        "lodash._basecreatewrapper": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
-          "integrity": "sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=",
-          "requires": {
-            "lodash._basecreate": "~2.4.1",
-            "lodash._setbinddata": "~2.4.1",
-            "lodash._slice": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
-          }
-        },
-        "lodash._basetostring": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
-        },
-        "lodash._basevalues": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-          "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
-        },
-        "lodash._createwrapper": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
-          "integrity": "sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=",
-          "requires": {
-            "lodash._basebind": "~2.4.1",
-            "lodash._basecreatewrapper": "~2.4.1",
-            "lodash._slice": "~2.4.1",
-            "lodash.isfunction": "~2.4.1"
-          }
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-        },
-        "lodash._isiterateecall": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-          "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-        },
-        "lodash._isnative": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
-        },
-        "lodash._objecttypes": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
-        },
-        "lodash._reinterpolate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-        },
-        "lodash._replaceholders": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz",
-          "integrity": "sha1-iru3EmxDH37XRPe6rznwi8m9nVg="
-        },
-        "lodash._setbinddata": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
-          "integrity": "sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=",
-          "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash.noop": "~2.4.1"
-          }
-        },
-        "lodash._shimkeys": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-          "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-          "requires": {
-            "lodash._objecttypes": "~2.4.1"
-          }
-        },
-        "lodash._slice": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
-          "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8="
-        },
-        "lodash.assign": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
-          "integrity": "sha1-hMOVlt1xGBqXsGUpE6fJZ15Jsao=",
-          "requires": {
-            "lodash._basecreatecallback": "~2.4.1",
-            "lodash._objecttypes": "~2.4.1",
-            "lodash.keys": "~2.4.1"
-          }
-        },
-        "lodash.bind": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
-          "integrity": "sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=",
-          "requires": {
-            "lodash._createwrapper": "~2.4.1",
-            "lodash._slice": "~2.4.1"
-          }
-        },
-        "lodash.escape": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
-          "integrity": "sha1-+ylMmae/tYYDn2bWucJ+2HTLe1E=",
-          "requires": {
-            "lodash._basetostring": "^3.0.0"
-          }
-        },
-        "lodash.identity": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
-          "integrity": "sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE="
-        },
-        "lodash.isarguments": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-          "integrity": "sha1-67uITEjSc2akTqb+5X7XtaMqgeA="
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-        },
-        "lodash.isfunction": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
-          "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE="
-        },
-        "lodash.isobject": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-          "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-          "requires": {
-            "lodash._objecttypes": "~2.4.1"
-          }
-        },
-        "lodash.keys": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
-          }
-        },
-        "lodash.noop": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
-          "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o="
-        },
-        "lodash.partial": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.partial/-/lodash.partial-3.1.1.tgz",
-          "integrity": "sha1-q0pqtuMvA+yxUZBIzbrlAmgAU+U=",
-          "requires": {
-            "lodash._createwrapper": "^3.0.0",
-            "lodash._replaceholders": "^3.0.0",
-            "lodash.restparam": "^3.0.0"
-          },
-          "dependencies": {
-            "lodash._basecreate": {
-              "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-              "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
-            },
-            "lodash._createwrapper": {
-              "version": "3.0.7",
-              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
-              "integrity": "sha1-bcCVY9Y1wKwYxKsZTZINCd6Om8c=",
-              "requires": {
-                "lodash._arraycopy": "^3.0.0",
-                "lodash._basecreate": "^3.0.0",
-                "lodash._replaceholders": "^3.0.0"
-              }
-            }
-          }
-        },
-        "lodash.restparam": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-        },
-        "lodash.support": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
-          "integrity": "sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=",
-          "requires": {
-            "lodash._isnative": "~2.4.1"
-          }
-        },
-        "lodash.template": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-          "requires": {
-            "lodash._basecopy": "^3.0.0",
-            "lodash._basetostring": "^3.0.0",
-            "lodash._basevalues": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0",
-            "lodash._reinterpolate": "^3.0.0",
-            "lodash.escape": "^3.0.0",
-            "lodash.keys": "^3.0.0",
-            "lodash.restparam": "^3.0.0",
-            "lodash.templatesettings": "^3.0.0"
-          },
-          "dependencies": {
-            "lodash.keys": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-              "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-              "requires": {
-                "lodash._getnative": "^3.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isarray": "^3.0.0"
-              }
-            }
-          }
-        },
-        "lodash.templatesettings": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
-          "integrity": "sha1-U4Uv2DK5IGBaLrYZGby7+484W7Y=",
-          "requires": {
-            "lodash._reinterpolate": "^3.0.0",
-            "lodash.escape": "^3.0.0"
-          }
-        },
-        "loud-rejection": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
-          "integrity": "sha1-19oHN36+jHacmp3/QrImsIXoMkY="
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-        },
-        "map-stream": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-          "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
-        },
-        "meow": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.5.0.tgz",
-          "integrity": "sha1-vFpdi1uEjvaqUBWL4FcBgusNXk0=",
-          "requires": {
-            "camelcase-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
-          },
-          "dependencies": {
-            "normalize-package-data": {
-              "version": "2.3.5",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-              "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-              }
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "normalize-package-data": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
-          "integrity": "sha1-i+lVuJB6+XXxpFhOqLubQUkjEvU=",
-          "requires": {
-            "github-url-from-git": "^1.3.0",
-            "github-url-from-username-repo": "^1.0.0",
-            "semver": "2 || 3 || 4"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "4.3.6",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-              "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
-            }
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
-        },
-        "object-assign": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-          "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
-          "integrity": "sha1-xO/jfX/ceS+aApznkG4JXhafm+E=",
-          "requires": {
-            "pinkie-promise": "^1.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
-          "integrity": "sha1-UbEn1IhBAPWAglbkXUcXFroW9i0=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^1.0.0"
-          }
-        },
-        "pause-stream": {
-          "version": "0.0.11",
-          "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-          "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-          "requires": {
-            "through": "~2.3"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pinkie": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
-        },
-        "pinkie-promise": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-          "requires": {
-            "pinkie": "^1.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          },
-          "dependencies": {
-            "normalize-package-data": {
-              "version": "2.3.5",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-              "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-              }
-            }
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
-          }
-        },
-        "repeating": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-          "integrity": "sha1-/SfW0mTRj76/qlZVPde4JTWlA04=",
-          "requires": {
-            "is-finite": "^1.0.0"
-          }
-        },
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-          "requires": {
-            "spdx-license-ids": "^1.0.2"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-          "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0="
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.1.tgz",
-          "integrity": "sha1-u08u0A1QRzqUn3ozPYTswattSD0=",
-          "requires": {
-            "spdx-exceptions": "^1.0.4",
-            "spdx-license-ids": "^1.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
-          "integrity": "sha1-KGlKzfOf4n3kUUP/+B8h9sZtRKw="
-        },
-        "split": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-          "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-          "requires": {
-            "through": "2"
-          }
-        },
-        "stream-combiner": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-          "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-          "requires": {
-            "duplexer": "~0.1.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "requires": {
-            "get-stdin": "^4.0.1"
-          },
-          "dependencies": {
-            "get-stdin": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-              "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-            }
-          }
-        },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "requires": {
-            "spdx-correct": "~1.0.0",
-            "spdx-expression-parse": "~1.0.0"
-          }
-        }
+      "requires": {
+        "eslint-plugin-lob": "^1.0.1"
       }
+    },
+    "eslint-plugin-lob": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-lob/-/eslint-plugin-lob-1.2.0.tgz",
+      "integrity": "sha512-K/DWsoXpyt802f5f5tTwV6ouE/O89bUPd9FPGtUizu6H1c+9Zy68FnGeKJP02QGgmAgbVH/WVCjutsepKNlxKQ==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "4.0.0",
@@ -1767,6 +1203,12 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1817,6 +1259,27 @@
         }
       }
     },
+    "istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
+      "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "istanbul-lib-coverage": "^2.0.1",
+        "semver": "^5.5.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1846,6 +1309,12 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-2-csv": {
       "version": "1.5.0",
@@ -2107,6 +1576,1145 @@
       "dev": true,
       "requires": {
         "abbrev": "1"
+      }
+    },
+    "nyc": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
+      "integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^2.0.0",
+        "convert-source-map": "^1.6.0",
+        "debug-log": "^1.0.1",
+        "find-cache-dir": "^2.0.0",
+        "find-up": "^3.0.0",
+        "foreground-child": "^1.5.6",
+        "glob": "^7.1.3",
+        "istanbul-lib-coverage": "^2.0.1",
+        "istanbul-lib-hook": "^2.0.1",
+        "istanbul-lib-instrument": "^3.0.0",
+        "istanbul-lib-report": "^2.0.2",
+        "istanbul-lib-source-maps": "^2.0.1",
+        "istanbul-reports": "^2.0.1",
+        "make-dir": "^1.3.0",
+        "merge-source-map": "^1.1.0",
+        "resolve-from": "^4.0.0",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^5.0.0",
+        "uuid": "^3.3.2",
+        "yargs": "11.1.0",
+        "yargs-parser": "^9.0.2"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "^2.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "make-dir": "^1.0.0",
+            "md5-hex": "^2.0.0",
+            "package-hash": "^2.0.0",
+            "write-file-atomic": "^2.0.0"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es6-error": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "^1.0.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^2.0.1",
+            "make-dir": "^1.3.0",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^2.0.1",
+            "make-dir": "^1.3.0",
+            "rimraf": "^2.6.2",
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "^4.0.11"
+          }
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "md5-hex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "^0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.10",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "package-hash": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "lodash.flattendeep": "^4.4.0",
+            "md5-hex": "^2.0.0",
+            "release-zalgo": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "release-zalgo": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es6-error": "^4.0.1"
+          }
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "test-exclude": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "minimatch": "^3.0.4",
+            "read-pkg-up": "^4.0.0",
+            "require-main-filename": "^1.0.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          },
+          "dependencies": {
+            "cliui": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
       }
     },
     "object-assign": {
@@ -2616,6 +3224,18 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "tslib": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -20,15 +20,17 @@
   "devDependencies": {
     "chai": "^2.2.0",
     "coveralls": "^3.0.2",
+    "cross-env": "^5.2.0",
     "csv-parse": "^0.1.1",
     "eslint": "^5.5.0",
-    "eslint-config-lob": "^1.0.1",
+    "eslint-config-lob": "^3.0.0",
     "generate-changelog": "^1.0.0",
     "istanbul": "^0.4.5",
     "json-2-csv": "^1.3.0",
     "mocha": "~5.2.0",
     "mocha-lcov-reporter": "0.0.2",
     "moment": "^2.22.1",
+    "nyc": "^13.1.0",
     "uuid": "^3.1.0"
   },
   "repository": {
@@ -41,14 +43,21 @@
     "node": ">= 4.0.0"
   },
   "scripts": {
-    "test": "NODE_ENV=test istanbul cover _mocha -- test --recursive --timeout 30000",
-    "test-no-cover": "NODE_ENV=test mocha test --recursive --timeout 30000",
-    "enforce": "istanbul check-coverage --statement 100 --branch 100 --function 100 --lines 100",
-    "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "test": "cross-env NODE_ENV=test nyc mocha test --recursive --timeout 30000",
+    "test-no-cover": "cross-env NODE_ENV=test mocha test --recursive --timeout 30000",
+    "coverage": "nyc report --reporter=text",
+    "enforce": "nyc check-coverage --statements 100 --lines 100 --functions 100 --branches 100",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "release:patch": "changelog -p && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version patch && git push origin && git push origin --tags",
     "release:minor": "changelog -m && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version minor && git push origin && git push origin --tags",
     "release:major": "changelog -M && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version major && git push origin && git push origin --tags"
+  },
+  "nyc": {
+    "include": [
+      "lib/**/*.js"
+    ]
   },
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "bugs:": "https://github.com/lob/lob-node/issues",
   "main": "./lib/index",
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 6.0.0"
   },
   "scripts": {
     "test": "cross-env NODE_ENV=test nyc mocha test --recursive --timeout 30000",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "generate-changelog": "^1.0.0",
     "json-2-csv": "^1.3.0",
     "mocha": "~5.2.0",
-    "mocha-lcov-reporter": "0.0.2",
     "moment": "^2.22.1",
     "nyc": "^13.1.0",
     "uuid": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cross-env": "^5.2.0",
     "csv-parse": "^0.1.1",
     "eslint": "^5.5.0",
-    "eslint-config-lob": "^3.0.0",
+    "eslint-config-lob": "^1.0.1",
     "generate-changelog": "^1.0.0",
     "json-2-csv": "^1.3.0",
     "mocha": "~5.2.0",
@@ -61,5 +61,6 @@
   "files": [
     "lib",
     "LICENSE.txt"
-  ]
+  ],
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "eslint": "^5.5.0",
     "eslint-config-lob": "^3.0.0",
     "generate-changelog": "^1.0.0",
-    "istanbul": "^0.4.5",
     "json-2-csv": "^1.3.0",
     "mocha": "~5.2.0",
     "mocha-lcov-reporter": "0.0.2",

--- a/test/addresses.js
+++ b/test/addresses.js
@@ -20,8 +20,8 @@ describe('addresses', () => {
       Lob.addresses.list((err, res) => {
         expect(res.object).to.eql('list');
         expect(res.data).to.be.instanceof(Array);
-        expect(res.data.length).to.eql(10);
-        expect(res.count).to.eql(10);
+        expect(res.data.length <= 10).to.be.true;
+        expect(res.count <= 10).to.be.true;
         return done();
       });
     });

--- a/test/addresses.js
+++ b/test/addresses.js
@@ -20,8 +20,8 @@ describe('addresses', () => {
       Lob.addresses.list((err, res) => {
         expect(res.object).to.eql('list');
         expect(res.data).to.be.instanceof(Array);
-        expect(res.data.length <= 10).to.be.true;
-        expect(res.count <= 10).to.be.true;
+        expect(res.data.length).to.be.at.most(10);
+        expect(res.count).to.be.at.most(10);
         return done();
       });
     });

--- a/test/bankAccounts.js
+++ b/test/bankAccounts.js
@@ -60,8 +60,8 @@ describe('bank accounts', () => {
       Lob.bankAccounts.list((err, res) => {
         expect(res.object).to.eql('list');
         expect(res.data).to.be.instanceof(Array);
-        expect(res.data.length <= 10).to.be.true;
-        expect(res.count <= 10).to.be.true;
+        expect(res.data.length).to.be.at.most(10);
+        expect(res.count).to.be.at.most(10);
         return done();
       });
     });

--- a/test/bankAccounts.js
+++ b/test/bankAccounts.js
@@ -60,8 +60,8 @@ describe('bank accounts', () => {
       Lob.bankAccounts.list((err, res) => {
         expect(res.object).to.eql('list');
         expect(res.data).to.be.instanceof(Array);
-        expect(res.data.length).to.eql(10);
-        expect(res.count).to.eql(10);
+        expect(res.data.length <= 10).to.be.true;
+        expect(res.count <= 10).to.be.true;
         return done();
       });
     });
@@ -84,7 +84,7 @@ describe('bank accounts', () => {
       const amounts = [23, 34];
 
       Lob.bankAccounts.create(BANK_ACCOUNT, (err, res) => {
-        Lob.bankAccounts.verify(res.id, { amounts: amounts }, (err, res) => {
+        Lob.bankAccounts.verify(res.id, { amounts }, (err, res) => {
           expect(res).to.have.property('id');
           expect(res.routing_number).to.eql(BANK_ACCOUNT.routing_number);
           expect(res.account_number).to.eql(BANK_ACCOUNT.account_number);

--- a/test/checks.js
+++ b/test/checks.js
@@ -101,8 +101,8 @@ describe('checks', () => {
       Lob.checks.list((err, res) => {
         expect(res.object).to.eql('list');
         expect(res.data).to.be.instanceof(Array);
-        expect(res.data.length <= 10).to.be.true;
-        expect(res.count <= 10).to.be.true;
+        expect(res.data.length).to.be.at.most(10);
+        expect(res.count).to.be.at.most(10);
         return done();
       });
     });

--- a/test/checks.js
+++ b/test/checks.js
@@ -21,16 +21,20 @@ const BANK_ACCOUNT = {
 
 describe('checks', () => {
 
-  before(async () => {
-    await Lob.addresses.list({ limit: 1 }).then(res => {
-      CHECK.to = res.data[0].id;
-      CHECK.from = res.data[0].id;
-    });
-    await Lob.bankAccounts.create(BANK_ACCOUNT).then(res => {
-      CHECK.bank_account = res.id;
-    });
-    await Lob.bankAccounts.verify(CHECK.bank_account, { amounts: [23, 34] });
-  })
+  before(() => {
+    return new Promise((resolve, reject) => {
+      Lob.addresses.list({ limit: 1 }, (err, res) => {
+        CHECK.to = res.data[0].id;
+        CHECK.from = res.data[0].id;
+        Lob.bankAccounts.create(BANK_ACCOUNT, (err, res) => {
+          CHECK.bank_account = res.id;
+          Lob.bankAccounts.verify(res.id, { amounts: [23, 34] }, (err, res) => {
+            resolve();
+          });
+        });
+      });
+    })
+  });
 
   describe('create', () => {
 

--- a/test/checks.js
+++ b/test/checks.js
@@ -4,15 +4,33 @@ const uuid = require('uuid/v1');
 
 const CHECK = {
   description: 'TEST_CHECK',
-  bank_account: 'bank_42426d3c5c2ffd2',
-  to: 'adr_eed2a7b59384aea7',
-  from: 'adr_eed2a7b59384aea7',
+  bank_account: '',
+  to: '',
+  from: '',
   amount: 100,
   memo: 'test check',
   check_bottom: '<h1>Test Check</h1>'
 };
 
+const BANK_ACCOUNT = {
+  routing_number: '122100024',
+  account_number: '123456788',
+  account_type: 'company',
+  signatory: 'John Doe'
+};
+
 describe('checks', () => {
+
+  before(async () => {
+    await Lob.addresses.list({ limit: 1 }).then(res => {
+      CHECK.to = res.data[0].id;
+      CHECK.from = res.data[0].id;
+    });
+    await Lob.bankAccounts.create(BANK_ACCOUNT).then(res => {
+      CHECK.bank_account = res.id;
+    });
+    await Lob.bankAccounts.verify(CHECK.bank_account, { amounts: [23, 34] });
+  })
 
   describe('create', () => {
 
@@ -37,20 +55,20 @@ describe('checks', () => {
       },
         (err, res) => {
           Lob.checks.create(CHECK, {
-          'idempotency-key': idempotencyKey
-        },
-        (err, resTwo) => {
-          expect(res.id).to.eql(resTwo.id);
-          expect(res).to.have.property('id');
-          expect(res).to.have.property('description');
-          expect(res).to.have.property('bank_account');
-          expect(res).to.have.property('check_number');
-          expect(res).to.have.property('memo');
-          expect(res.memo).to.eql('test check');
-          expect(res.object).to.eql('check');
-          return done();
+            'idempotency-key': idempotencyKey
+          },
+            (err, resTwo) => {
+              expect(res.id).to.eql(resTwo.id);
+              expect(res).to.have.property('id');
+              expect(res).to.have.property('description');
+              expect(res).to.have.property('bank_account');
+              expect(res).to.have.property('check_number');
+              expect(res).to.have.property('memo');
+              expect(res.memo).to.eql('test check');
+              expect(res.object).to.eql('check');
+              return done();
+            });
         });
-      });
     });
 
   });
@@ -79,8 +97,8 @@ describe('checks', () => {
       Lob.checks.list((err, res) => {
         expect(res.object).to.eql('list');
         expect(res.data).to.be.instanceof(Array);
-        expect(res.data.length).to.eql(10);
-        expect(res.count).to.eql(10);
+        expect(res.data.length <= 10).to.be.true;
+        expect(res.count <= 10).to.be.true;
         return done();
       });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -3,12 +3,12 @@
 describe('Lob', () => {
 
   it('allows specifying a version', () => {
-    var Lob = require('../lib')(API_KEY, { apiVersion: 'api_version' });
+    const Lob = require('../lib')(API_KEY, { apiVersion: 'api_version' });
     expect(Lob.options.headers['Lob-Version']).to.eql('api_version');
   });
 
   it('allows the use of promises and callbacks', (done) => {
-    var Lob = require('../lib')(API_KEY);
+    const Lob = require('../lib')(API_KEY);
 
     Lob.addresses.list()
     .then((result) => {
@@ -18,23 +18,23 @@ describe('Lob', () => {
   });
 
   it('allows options to override defaults (such as host)', () => {
-    var options = { host: 'http://test' };
-    var Lob = require('../lib')(API_KEY, options);
+    const options = { host: 'http://test' };
+    const Lob = require('../lib')(API_KEY, options);
 
     expect(Lob.options.host).to.eql('http://test');
   });
 
   it('allows options object as first argument', () => {
-    var options = { apiKey: API_KEY, host: 'http://test' };
-    var Lob     = require('../lib')(options);
+    const options = { apiKey: API_KEY, host: 'http://test' };
+    const Lob = require('../lib')(options);
 
     expect(Lob.options.apiKey).to.eql(API_KEY);
     expect(Lob.options.host).to.eql('http://test');
   });
 
   it('should propagate request errors', (done) => {
-    var options = { host: 'http://test' };
-    var Lob     = require('../lib')(API_KEY, options);
+    const options = { host: 'http://test' };
+    const Lob = require('../lib')(API_KEY, options);
 
     Lob.addresses.list()
     .catch((err) => {

--- a/test/letters.js
+++ b/test/letters.js
@@ -21,8 +21,8 @@ describe('letters', () => {
       Lob.letters.list((err, res) => {
         expect(res.object).to.eql('list');
         expect(res.data).to.be.instanceof(Array);
-        expect(res.data.length).to.eql(10);
-        expect(res.count).to.eql(10);
+        expect(res.data.length <= 10).to.be.true;
+        expect(res.count <= 10).to.be.true;
         done();
       });
     });
@@ -82,7 +82,7 @@ describe('letters', () => {
         description: 'Test Letter',
         to: ADDRESS,
         from: ADDRESS,
-        file: file,
+        file,
         color: false
       }, (err, res) => {
         expect(res.object).to.eql('letter');

--- a/test/letters.js
+++ b/test/letters.js
@@ -21,8 +21,8 @@ describe('letters', () => {
       Lob.letters.list((err, res) => {
         expect(res.object).to.eql('list');
         expect(res.data).to.be.instanceof(Array);
-        expect(res.data.length <= 10).to.be.true;
-        expect(res.count <= 10).to.be.true;
+        expect(res.data.length).to.be.at.most(10);
+        expect(res.count).to.be.at.most(10);
         done();
       });
     });

--- a/test/postcards.js
+++ b/test/postcards.js
@@ -21,8 +21,8 @@ describe('postcards', () => {
       Lob.postcards.list((err, res) => {
         expect(res.object).to.eql('list');
         expect(res.data).to.be.instanceof(Array);
-        expect(res.data.length <= 10).to.be.true;
-        expect(res.count <= 10).to.be.true;
+        expect(res.data.length).to.be.at.most(10);
+        expect(res.count).to.be.at.most(10);
         done();
       });
     });

--- a/test/postcards.js
+++ b/test/postcards.js
@@ -21,8 +21,8 @@ describe('postcards', () => {
       Lob.postcards.list((err, res) => {
         expect(res.object).to.eql('list');
         expect(res.data).to.be.instanceof(Array);
-        expect(res.data.length).to.eql(10);
-        expect(res.count).to.eql(10);
+        expect(res.data.length <= 10).to.be.true;
+        expect(res.count <= 10).to.be.true;
         done();
       });
     });

--- a/test/resourceBase.js
+++ b/test/resourceBase.js
@@ -19,7 +19,7 @@ describe('resource base', () => {
   });
 
   it('should expose the raw response on 400 level error', (done) => {
-    Lob.addresses.retrieve('adr_bad_id', (err, res) => {
+    Lob.addresses.retrieve('adr_bad_id', (err) => {
       expect(err._response).to.exist;
       done();
     });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,8 +1,8 @@
-'use strict'
+'use strict';
 
-var Chai = require('chai');
+const Chai = require('chai');
 
-var API_KEY = process.env.LOB_API_KEY;
+const API_KEY = process.env.LOB_API_KEY;
 
 global.expect = Chai.expect;
 global.API_KEY = API_KEY;

--- a/test/usAutocompletions.js
+++ b/test/usAutocompletions.js
@@ -8,7 +8,7 @@ describe('us_autocompletions', () => {
       Lob.usAutocompletions.autocomplete({
         address_prefix: '185 BER',
         city: 'San Francisco',
-        state: 'CA',
+        state: 'CA'
       }, (err, res) => {
         expect(err).to.not.exist;
         expect(res.suggestions).to.exist;

--- a/test/usVerifications.js
+++ b/test/usVerifications.js
@@ -6,7 +6,7 @@ describe('us_verifications', () => {
 
     it('verifies an address', (done) => {
       Lob.usVerifications.verify({
-        primary_line: 'deliverable',
+        primary_line: '1 Telegraph Hill Blvd',
         city: 'San Francisco',
         state: 'CA',
         zip_code: '94107'
@@ -19,7 +19,7 @@ describe('us_verifications', () => {
 
     it('verifies an address with custom case', (done) => {
       Lob.usVerifications.verify({
-        primary_line: 'deliverable',
+        primary_line: '1 Telegraph Hill Blvd',
         city: 'San Francisco',
         state: 'CA',
         zip_code: '94107'

--- a/test/usVerifications.js
+++ b/test/usVerifications.js
@@ -6,7 +6,7 @@ describe('us_verifications', () => {
 
     it('verifies an address', (done) => {
       Lob.usVerifications.verify({
-        primary_line: '1 Telegraph Hill Blvd',
+        primary_line: 'deliverable',
         city: 'San Francisco',
         state: 'CA',
         zip_code: '94107'
@@ -19,7 +19,7 @@ describe('us_verifications', () => {
 
     it('verifies an address with custom case', (done) => {
       Lob.usVerifications.verify({
-        primary_line: '1 Telegraph Hill Blvd',
+        primary_line: 'deliverable',
         city: 'San Francisco',
         state: 'CA',
         zip_code: '94107'


### PR DESCRIPTION
I wanted to do some testing and the NPM scripts were broken on Windows. I added [cross-env](https://github.com/kentcdodds/cross-env) to fix running them. Istanbul wasn't running after that, so I replaced it with [nyc](https://github.com/istanbuljs/nyc). Had to depreciate node v4 support, but LTS for it has been dropped since April 30, 2018.

Had to clean up some other things in tests, like checking the length of the response to be equal to 10. If there weren't enough addresses, checks, etc. the tests would fail. Would have to run it several times starting from scratch before enough of them were created or just create 10 objects from the get-go. Also tried bumping the `eslint-config-lob` version to latest, but it was causing Travis to have a fit, so I turned it back. I can clean up some of the changes it made, like removing semi-colons, if you'd like!

Coverage seems to be working fine, but I've never used Coveralls, so that might need some tweaking. Also may be able to remove `mocha-lcov-reporter` now that `nyc` is being used. Wanted to get this PR out there so I could get some thoughts before I went any further on it!

Let me know what you think!