### PR TITLE
feat(resource): add ability to specify custom HTTP agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The Lob constructor accepts an `options` object which may contain one or more of
 * `host` - Override the default host API calls are issued to.
 * `userAgent` - Override the default userAgent.
 * `headers` - Edit the headers sent in all API calls.
+* `agent` - Override the default HTTP agent used to make requests.
 
 ## Examples
 

--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -29,6 +29,10 @@ class ResourceBase {
       json: true
     };
 
+    if (this.config.agent) {
+      opts.agent = this.config.agent;
+    }
+
     let isMultiPartForm = false;
 
     for (const key in form) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,6 +134,17 @@
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
     },
+    "agentkeepalive": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.0.tgz",
+      "integrity": "sha512-CW/n1wxF8RpEuuiq6Vbn9S8m0VSYDMnZESqaJ6F2cWN9fY8rei2qaxweIaRgq+ek8TqfoFIsUjaGNKGGEHElSg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -538,6 +549,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
     },
     "diff": {
       "version": "3.5.0",
@@ -1718,6 +1735,15 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "dev": true,
+      "requires": {
+        "ms": "^2.0.0"
       }
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
+    "agentkeepalive": "^4.1.0",
     "chai": "^2.2.0",
     "coveralls": "^3.0.5",
     "cross-env": "^5.2.0",

--- a/test/resourceBase.js
+++ b/test/resourceBase.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Agent = require('agentkeepalive');
+
 const ResourceBase = require('../lib/resources/resourceBase.js');
 
 describe('resource base', () => {
@@ -35,6 +37,21 @@ describe('resource base', () => {
 
     resource._transmit('POST', null, null, null, (err) => {
       expect(err._response).to.exist;
+      return done();
+    });
+  });
+
+  it('allows a custom HTTP agent', (done) => {
+    const resource = new ResourceBase('', {
+      options: {
+        host: 'https://mock.lob.com/200',
+        apiKey: API_KEY,
+        agent: new Agent.HttpsAgent()
+      }
+    });
+
+    resource._transmit('POST', null, null, null, (err) => {
+      expect(err).to.not.exist;
       return done();
     });
   });


### PR DESCRIPTION
Add the ability to provide a custom HTTP(s) agent. This is useful if you want to, say, use an HTTP agent like [agentkeepalive](https://github.com/node-modules/agentkeepalive) which uses HTTP keep-alive to make outgoing HTTP requests much more efficient.