### PR TITLE
fix(merge-variables): convert merge variables to JSON

### DIFF
--- a/lib/resources/checks.js
+++ b/lib/resources/checks.js
@@ -26,6 +26,15 @@ class Checks extends ResourceBase {
   }
 
   create (params, headers, callback) {
+
+    for (const p in params) {
+
+      if (p === 'merge_variables' && params[p] instanceof Object) {
+        params[p] = JSON.stringify(params[p]);
+      }
+
+    }
+
     return this._transmit('POST', null, null, params, headers, callback);
   }
 

--- a/lib/resources/letters.js
+++ b/lib/resources/letters.js
@@ -43,6 +43,10 @@ class Letters extends ResourceBase {
 
     for (const p in params) {
 
+      if (p === 'merge_variables' && params[p] instanceof Object) {
+        params[p] = JSON.stringify(params[p]);
+      }
+
       if (p === 'file' || !(params[p] instanceof Object)) {
         continue;
       }

--- a/lib/resources/postcards.js
+++ b/lib/resources/postcards.js
@@ -54,6 +54,10 @@ class Postcards extends ResourceBase {
 
     for (const p in params) {
 
+      if (p === 'merge_variables' && params[p] instanceof Object) {
+        params[p] = JSON.stringify(params[p]);
+      }
+
       if (p === 'front' || p === 'back' || !(params[p] instanceof Object)) {
         continue;
       }

--- a/test/checks.js
+++ b/test/checks.js
@@ -52,6 +52,7 @@ describe('checks', () => {
         expect(res).to.have.property('memo');
         expect(res.memo).to.eql('test check');
         expect(res.object).to.eql('check');
+        expect(res.merge_variables.data.title).to.eql('Test Check');
         return done();
       });
     });

--- a/test/letters.js
+++ b/test/letters.js
@@ -152,6 +152,8 @@ describe('letters', () => {
         }
       }, (err, res) => {
         expect(res.object).to.eql('letter');
+        expect(res.merge_variables.list[0].name).to.eql('Ami');
+        expect(res.merge_variables.list[1].name).to.eql('Nathan');
         done();
       });
 

--- a/test/postcards.js
+++ b/test/postcards.js
@@ -124,6 +124,7 @@ describe('postcards', () => {
         }
       }, (err, res) => {
         expect(res.object).to.eql('postcard');
+        expect(res.merge_variables.is_awesome).to.be.true;
         done();
       });
     });


### PR DESCRIPTION
## What

Converts `merge_variables` into JSON

## Why

So we can properly use merge variable conditionals in the templating syntax