### PR TITLE
feat(examples): added a bunch of examples which were in the old docs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,9 @@
 # Node.js Examples
 
-Here we have put together a hand full of Node.js examples to help get you started. Please read through the official [API Documentation](../README.md#api-documentation) to get a complete sense of what to expect from each endpoint. As always, feel free to [contact us](https://lob.com/support) directly if you have any questions on implementation.
+Here we have put together a hand full of Node.js examples to help get you started. Please read through the official [API Documentation](https://docs.lob.com/) to get a complete sense of what to expect from each endpoint. As always, feel free to [contact us](https://lob.com/support) directly if you have any questions on implementation.
+
+There are a number of different examples of postcard requests which illustrate different cases, such as making an idempotent request or sending to
+an international address.
 
 ## Getting started
 Before running these examples make sure you are in the `examples/` directory.
@@ -14,7 +17,7 @@ cd examples/
 
 An example showing how to validate and clean addresses from a CSV spreadsheet full of mailing addresses using Lob's [US Address Verification API](https://lob.com/services/verifications) and then using the clean, valid addresses to dynamically create sample billing letters with merge variables using Lob's [Letter API](https://lob.com/services/letters).
 
-Please note that if you are running this with a Test API Key, the verification API will always return [a dummy address](https://lob.com/docs#us_verifications_create).
+Please note that if you are running this with a Test API Key, the verification API will always return [a dummy address](https://docs.lob.com/#section/US-Verifications-Test-Env).
 
 In order to run the program enter:
 
@@ -47,6 +50,36 @@ node create_letter.js
 ### Create a postcard
 ```
 node create_postcard.js
+```
+
+### Create an international postcard
+```
+node create_postcard_intl.js
+```
+
+### Create an idempotent postcard request
+```
+node create_postcard_idempotent.js
+```
+
+### Create a postcard with metadata
+```
+node create_postcard_metadata.js
+```
+
+### Create a postcard with remote files
+```
+node create_postcard_remote.js
+```
+
+### Create a postcard with a send date specified
+```
+node create_postcard_send_date.js
+```
+
+### Create a postcard using saved HTML templates
+```
+node create_postcard_template.js
 ```
 
 ### Create a self mailer

--- a/examples/create_postcard_idempotent.js
+++ b/examples/create_postcard_idempotent.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/*
+ * Create an address, then send a postcard with a custom PDF back.
+ * Run me! This example works out of the box, "batteries included".
+ */
+
+const fs = require('fs');
+
+const lobFactory = require('../lib/index.js');
+const Lob = new lobFactory('YOUR_API_KEY');
+
+const file = fs.readFileSync(`${__dirname}/html/card.html`).toString();
+
+// Create the address
+Lob.addresses.create({
+  name: 'Robin Joseph',
+  email: 'test@gmail.com',
+  phone: '123456789',
+  address_line1: '123 Test Street',
+  address_line2: 'Unit 199',
+  address_city: 'Chicago',
+  address_state: 'IL',
+  address_zip: '60012',
+  address_country: 'US'
+}, (err, address) => {
+  if (err) {
+    console.log(err);
+  } else {
+    Lob.postcards.create({
+      description: 'My Second Postcard',
+      to: address.id,
+      front: file,
+      back: file,
+      merge_variables: {
+        name: 'Robin'
+      }
+    },
+    {'Idempotency-Key': '026e7634-24d7-486c-a0bb-4a17fd0eebc5'},
+    (err, postcard) => {
+      if (err) {
+        console.log(err);
+      } else {
+        console.log('The Lob API responded with this postcard object: ', postcard);
+      }
+    });
+  }
+});

--- a/examples/create_postcard_intl.js
+++ b/examples/create_postcard_intl.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/*
+ * Create an international address, then send a postcard with a custom PDF back.
+ * Run me! This example works out of the box, "batteries included".
+ */
+
+const fs = require('fs');
+
+const lobFactory = require('../lib/index.js');
+const Lob = new lobFactory('YOUR_API_KEY');
+
+const file = fs.readFileSync(`${__dirname}/html/card.html`).toString();
+
+// Create the from address
+async function getFrom() {
+  const from_address = await Lob.addresses.create({
+    name: 'Harry Zhang',
+    email: 'harry@lob.com',
+    phone: '5555555555',
+    address_line1: '210 KING ST',
+    address_line2: '',
+    address_city: 'SAN FRANCISCO',
+    address_state: 'CA',
+    address_zip: '94107'
+  });
+
+  return from_address.id;
+}
+
+async function createPostcard() {
+  const from_id = await getFrom();
+
+  // Create the address
+  Lob.addresses.create({
+    name: 'Harry Zhang',
+    email: 'harry@lob.com',
+    phone: '5555555555',
+    address_line1: '370 WATER ST',
+    address_line2: '',
+    address_city: 'SUMMERSIDE',
+    address_state: 'PRINCE EDWARD ISLAND',
+    address_zip: 'C1N 1C4',
+    address_country: 'CA'
+  }, (err, address) => {
+    if (err) {
+      console.log(err);
+    } else {
+      Lob.postcards.create({
+        description: 'My Second Postcard',
+        to: address.id,
+        from: from_id,
+        front: file,
+        back: file,
+        merge_variables: {
+          name: 'Robin'
+        }
+      }, (err, postcard) => {
+        if (err) {
+          console.log(err);
+        } else {
+          console.log('The Lob API responded with this postcard object: ', postcard);
+        }
+      });
+    }
+  }); 
+}
+
+createPostcard();

--- a/examples/create_postcard_metadata.js
+++ b/examples/create_postcard_metadata.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/*
+ * Create an address, then send a postcard with a custom PDF back.
+ * Run me! This example works out of the box, "batteries included".
+ */
+
+const fs = require('fs');
+
+const lobFactory = require('../lib/index.js');
+const Lob = new lobFactory('test_efce9e9b96019137d711f4ce642ea11305b');
+
+const file = fs.readFileSync(`${__dirname}/html/card.html`).toString();
+
+// Create the address
+Lob.addresses.create({
+  name: 'Robin Joseph',
+  email: 'test@gmail.com',
+  phone: '123456789',
+  address_line1: '123 Test Street',
+  address_line2: 'Unit 199',
+  address_city: 'Chicago',
+  address_state: 'IL',
+  address_zip: '60012',
+  address_country: 'US'
+}, (err, address) => {
+  if (err) {
+    console.log(err);
+  } else {
+    Lob.postcards.create({
+      description: 'My Second Postcard',
+      to: address.id,
+      front: file,
+      back: file,
+      metadata: {
+        campaign: 'NEWYORK2015'
+      },
+      merge_variables: {
+        name: 'Robin'
+      }
+    }, (err, postcard) => {
+      if (err) {
+        console.log(err);
+      } else {
+        console.log('The Lob API responded with this postcard object: ', postcard);
+      }
+    });
+  }
+});

--- a/examples/create_postcard_remote.js
+++ b/examples/create_postcard_remote.js
@@ -1,0 +1,46 @@
+'use strict';
+
+/*
+ * Create an address, then send a postcard with a custom PDF back.
+ * Run me! This example works out of the box, "batteries included".
+ */
+
+const fs = require('fs');
+
+const lobFactory = require('../lib/index.js');
+const Lob = new lobFactory('YOUR_API_KEY');
+
+const file = fs.readFileSync(`${__dirname}/html/card.html`).toString();
+
+// Create the address
+Lob.addresses.create({
+  name: 'Robin Joseph',
+  email: 'test@gmail.com',
+  phone: '123456789',
+  address_line1: '123 Test Street',
+  address_line2: 'Unit 199',
+  address_city: 'Chicago',
+  address_state: 'IL',
+  address_zip: '60012',
+  address_country: 'US'
+}, (err, address) => {
+  if (err) {
+    console.log(err);
+  } else {
+    Lob.postcards.create({
+      description: 'My Second Postcard',
+      to: address.id,
+      front: 'https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/4x6_pc_template.pdf',
+      back: 'https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/4x6_pc_template.pdf',
+      merge_variables: {
+        name: 'Robin'
+      }
+    }, (err, postcard) => {
+      if (err) {
+        console.log(err);
+      } else {
+        console.log('The Lob API responded with this postcard object: ', postcard);
+      }
+    });
+  }
+});

--- a/examples/create_postcard_send_date.js
+++ b/examples/create_postcard_send_date.js
@@ -1,0 +1,49 @@
+'use strict';
+var moment = require('moment');
+
+/*
+ * Create an address, then send a postcard with a custom PDF back.
+ * Run me! This example works out of the box, "batteries included".
+ */
+
+const fs = require('fs');
+
+const lobFactory = require('../lib/index.js');
+const Lob = new lobFactory('YOUR_API_KEY');
+
+const file = fs.readFileSync(`${__dirname}/html/card.html`).toString();
+
+// Create the address
+const date = moment().date(moment().date() + 1).format('YYYY-MM-DD');
+Lob.addresses.create({
+  name: 'Robin Joseph',
+  email: 'test@gmail.com',
+  phone: '123456789',
+  address_line1: '123 Test Street',
+  address_line2: 'Unit 199',
+  address_city: 'Chicago',
+  address_state: 'IL',
+  address_zip: '60012',
+  address_country: 'US'
+}, (err, address) => {
+  if (err) {
+    console.log(err);
+  } else {
+    Lob.postcards.create({
+      description: 'My Second Postcard',
+      to: address.id,
+      front: file,
+      back: file,
+      send_date: date,
+      merge_variables: {
+        name: 'Robin'
+      }
+    }, (err, postcard) => {
+      if (err) {
+        console.log(err);
+      } else {
+        console.log('The Lob API responded with this postcard object: ', postcard);
+      }
+    });
+  }
+});

--- a/examples/create_postcard_template.js
+++ b/examples/create_postcard_template.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/*
+ * Create an address, then send a postcard with a custom PDF back.
+ * Run me! This example works out of the box, "batteries included".
+ */
+
+const fs = require('fs');
+
+const lobFactory = require('../lib/index.js');
+// this key is publicly available in the legacy docs, so it's hardcoded
+// since the templates are associated with this dummy account
+// you can replace this key with your own, and the IDs below with any
+// saved templates you have
+const Lob = new lobFactory('test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc');
+
+const file = fs.readFileSync(`${__dirname}/html/card.html`).toString();
+
+// Create the address
+Lob.addresses.create({
+  name: 'Robin Joseph',
+  email: 'test@gmail.com',
+  phone: '123456789',
+  address_line1: '123 Test Street',
+  address_line2: 'Unit 199',
+  address_city: 'Chicago',
+  address_state: 'IL',
+  address_zip: '60012',
+  address_country: 'US'
+}, (err, address) => {
+  if (err) {
+    console.log(err);
+  } else {
+    Lob.postcards.create({
+      description: 'My Second Postcard',
+      to: address.id,
+      // you can replace these template IDs
+      front: 'tmpl_b846a20859ae11a',
+      back: 'tmpl_01b0d396a10c268',
+      merge_variables: {
+        name: 'Robin'
+      }
+    }, (err, postcard) => {
+      if (err) {
+        console.log(err);
+      } else {
+        console.log('The Lob API responded with this postcard object: ', postcard);
+      }
+    });
+  }
+});

--- a/examples/list_postcard_metadata.js
+++ b/examples/list_postcard_metadata.js
@@ -1,0 +1,70 @@
+'use strict';
+const util = require('util');
+
+/*
+ * Create an address, then send a postcard with a custom PDF back.
+ * Run me! This example works out of the box, "batteries included".
+ */
+
+const fs = require('fs');
+
+const lobFactory = require('../lib/index.js');
+const Lob = new lobFactory('YOUR_API_KEY');
+
+const file = fs.readFileSync(`${__dirname}/html/card.html`).toString();
+
+async function create_postcard() {
+  // Create the postcard
+  Lob.addresses.create({
+    name: 'Robin Joseph',
+    email: 'test@gmail.com',
+    phone: '123456789',
+    address_line1: '123 Test Street',
+    address_line2: 'Unit 199',
+    address_city: 'Chicago',
+    address_state: 'IL',
+    address_zip: '60012',
+    address_country: 'US'
+  }, (err, address) => {
+    if (err) {
+      console.log(err);
+    } else {
+      Lob.postcards.create({
+        description: 'My Second Postcard',
+        to: address.id,
+        front: file,
+        back: file,
+        metadata: {
+          campaign: 'NEWYORK2015'
+        },
+        merge_variables: {
+          name: 'Robin'
+        }
+      }, (err, postcard) => {
+        if (err) {
+          console.log(err);
+        } else {
+          console.log('The Lob API successfully created a postcard.');
+        }
+      });
+    }
+  });
+}
+
+async function list_postcards() {
+  await create_postcard();
+  Lob.postcards.list({
+    metadata: {
+      campaign: 'NEWYORK2015'
+    },
+    limit: 1
+  }, (err, list) => {
+    if (err) {
+      console.log(err);
+    } else {
+      console.log('The Lob API responded with this list: ', util.inspect(list, {depth: null}));
+    }
+  });
+}
+
+list_postcards();


### PR DESCRIPTION
I did change up a few things. I didn't include a separate international address creation request––I included it in a postcard example as well. I also didn't include the full-payload examples, since that's just adding more fields into the request (and, given the payloads in the live docs, quite self-explanatory).

This is now a separate ticket from the other languages. Since I began with Node, this one took the longest as I figured out which examples I needed to include. The other 5 languages should be quicker. 