### PR TITLE
Adding github action yml to automate npm publishing steps

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,47 @@
+# This is a basic workflow to automate the manual steps required for publishing updated versions of this SDK package to NPM
+
+name: NPM Publish
+
+# Run the workflow when a new release is published
+on:
+  release:
+      types: [created]
+
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # uses json prop reader to identify version from package.json (more info here https://github.com/marketplace/actions/get-json-property)
+      - name: Read node version from package.json
+        id: node_version
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: "package.json"
+          prop_path: "version"    
+      - run: "Node version found: echo ${{steps.node_version.outputs.prop}}"
+
+      # use node setup library (more info here https://github.com/actions/setup-node)
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.node_version.outputs.prop }}
+      
+      #run npm scripts to perform final validation 
+      - run: npm install
+      - run: npm run lint
+      - run: npm run test
+
+      #publishes to NPM using third party tool (more info here https://github.com/JS-DevTools/npm-publish)
+      - id: publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+        - if: steps.publish.outputs.type != 'none'
+          run: |  
+            echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"


### PR DESCRIPTION
This is largely modeled off of your pre-existing [npm-publish.yml](https://github.com/lob/ui-components/blob/main/.github/workflows/npm-publish.yml) with a few differences:

1. the prop-path is changed (the package.json has a different version naming attribute, see line 27)
2. we removed the 'npm run build-library' step