### PR TITLE
fix(Cards): Add card update route

### DIFF
--- a/lib/resources/cards.js
+++ b/lib/resources/cards.js
@@ -22,6 +22,10 @@ class Cards extends ResourceBase {
     return this._transmit('GET', id, null, null, callback);
   }
 
+  update (id, params, callback) {
+    return this._transmit('POST', id, null, params, callback);
+  }
+
   delete (id, callback) {
     return this._transmit('DELETE', id, null, null, callback);
   }

--- a/test/cards.js
+++ b/test/cards.js
@@ -47,6 +47,27 @@ describe('cards', () => {
 
   });
 
+  describe('update', () => {
+
+    it('updates a card', (done) => {
+      const params = { description: 'Test Card Updated Desc'}
+      Lob.cards.create({
+        description: 'Test Card',
+        front: file,
+        back: file,
+        size: '2.125x3.375',
+      }, (err, res) => {
+        console.log('res', res);
+        Lob.cards.update(res.id, params, (err2, res2) => {
+          expect(res2.object).to.eql('card');
+          expect(res2.description).to.eql('Test Card Updated Desc');
+          done();
+        });
+      });
+    });
+
+  });
+
   describe('create', () => {
 
     it('creates a card with a local file', (done) => {

--- a/test/cards.js
+++ b/test/cards.js
@@ -57,7 +57,6 @@ describe('cards', () => {
         back: file,
         size: '2.125x3.375',
       }, (err, res) => {
-        console.log('res', res);
         Lob.cards.update(res.id, params, (err2, res2) => {
           expect(res2.object).to.eql('card');
           expect(res2.description).to.eql('Test Card Updated Desc');


### PR DESCRIPTION
## What

Adds card update route to cards resource.

## Why

To expose existing cards update endpoint in SDK.