### PR TITLE
got rid of unnecessary stringify

### DIFF
--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -39,9 +39,6 @@ class ResourceBase {
       if (form[key] === undefined) {
         delete form[key];
       }
-      if (form[key] === true || form[key] === false) {
-        form[key] = form[key].toString();
-      }
     }
 
     for (const param in form) {


### PR DESCRIPTION
The deleted section was causing some issues. After doing some investigation, I _believe_ that deleting these lines is unlikely to mess up anything serious. I ran a `blame` and they were added for the 2015 variant of the API, which might have returned booleans as strings. I'm pretty sure we're not doing that now, so we should be good, but I'd still like to ensure that the change is correct.