### PR TITLE
Node test fixes

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,4 @@
 'use strict';
-const sinon = require('sinon');
 
 describe('Lob', () => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const sinon = require('sinon');
 
 describe('Lob', () => {
 
@@ -31,18 +32,4 @@ describe('Lob', () => {
     expect(Lob.options.apiKey).to.eql(API_KEY);
     expect(Lob.options.host).to.eql('http://test');
   });
-
-  it('should propagate request errors', (done) => {
-    const options = { host: 'http://test' };
-    const Lob = require('../lib')(API_KEY, options);
-
-    Lob.addresses.list().then((res) => {
-      done();
-    })
-    .catch((err) => {
-      expect(err.message).to.match(/getaddrinfo (ENOTFOUND|EAI_AGAIN)/);
-      done();
-    });
-  });
-
 });


### PR DESCRIPTION
- Removed test due to it not being relevant to our SDK. It only tested that `test.com` was reachable. This is out of our scope since we do not own that domain, we cannot control when it is live.