### PR TITLE
Update npm-publish.yml

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,9 @@
 name: NPM Publish
 
 # Run the workflow when a new release is published
-on: [release]
+on: 
+  release:
+    types: [published]
       
 
 


### PR DESCRIPTION
Narrows down the release event that we target. Otherwise, the task will run three different times. 