### PR TITLE
chore: reimplement PR to remove Bluebird dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage
 .nyc_output
 
 *.sublime-*
+.idea/

--- a/examples/create_postcards_from_csv/index.js
+++ b/examples/create_postcards_from_csv/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const bluebird = require('bluebird');
 const parse    = require('csv-parse');
 const fs       = require('fs');
+const pMap     = require('p-map')
 
 const lobFactory = require('../../lib/index.js');
 const Lob        = new lobFactory('YOUR_API_KEY');
@@ -16,7 +16,7 @@ parse(input, (err, rows) => {
   if (err) {
     return console.log(err);
   }
-  bluebird.map(rows, (row) => {
+  pMap(rows, (row) => {
     return Lob.postcards.create({
       to: {
         name: row[5],

--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -71,6 +71,7 @@ class ResourceBase {
 
     const promise = new Promise((resolve, reject) => {
       Request(opts, (err, resp, body) => {
+        /* istanbul ignore next */
         body = body || {};
 
         /* istanbul ignore next */

--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Bluebird = require('bluebird');
 const Request  = require('request');
 const Stream   = require('stream');
 
@@ -70,7 +69,7 @@ class ResourceBase {
       }
     }
 
-    return new Bluebird((resolve, reject) => {
+    const promise = new Promise((resolve, reject) => {
       Request(opts, (err, resp, body) => {
         body = body || {};
 
@@ -101,7 +100,13 @@ class ResourceBase {
 
         return resolve(body);
       });
-    }).nodeify(callback);
+    })
+
+    if (callback) {
+      promise.then(body => callback(null, body), err => callback(err));
+    }
+
+    return promise
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "homepage": "https://github.com/lob/lob-node",
   "author": "Lob <support@lob.com> (https://lob.com/)",
   "dependencies": {
-    "bluebird": "^3.0.6",
     "request": "^2.88.0"
   },
   "devDependencies": {
@@ -30,6 +29,7 @@
     "mocha": "~5.2.0",
     "moment": "^2.22.1",
     "nyc": "^14.1.1",
+    "p-map": "^2.1.0",
     "uuid": "^3.1.0"
   },
   "repository": {


### PR DESCRIPTION
A re-implementation of (PR 214)[https://github.com/lob/lob-node/pull/214]

This removes an unneeded dependency from legacy versions of node that did not natively support Promises

Co-authored-by: Josh Duff <me@JoshDuff.com>