### PR TITLE
feat(autocomplete): Allow Query Params

### DIFF
--- a/lib/resources/usAutocompletions.js
+++ b/lib/resources/usAutocompletions.js
@@ -8,8 +8,12 @@ class USAutocompletions extends ResourceBase {
     super('us_autocompletions', config);
   }
 
-  autocomplete (params, callback) {
-    return this._transmit('POST', null, null, params, null, callback);
+  autocomplete (params, query_param, callback) {
+    if (typeof query_param === 'function') {
+      callback = query_param;
+      query_param = {};
+    }
+    return this._transmit('POST', null, query_param, params, null, callback);
   }
 
 }

--- a/test/usAutocompletions.js
+++ b/test/usAutocompletions.js
@@ -18,18 +18,18 @@ describe('us_autocompletions', () => {
       });
     });
 
-    it('returns a list of suggestions with custom case', (done) => {
-      Lob.usVerifications.verify({
-        primary_line: 'deliverable',
+    it.only('returns a list of suggestions with custom case', (done) => {
+      Lob.usAutocompletions.autocomplete({
+        address_prefix: '185 BER',
         city: 'San Francisco',
-        state: 'CA',
-        zip_code: '94107'
+        state: 'CA'
       }, {
         case: 'proper'
       }, (err, res) => {
         expect(err).to.not.exist;
         expect(res.suggestions).to.exist;
-        expect(res.suggestions[0].primary_line).to.eql('TEST KEYS DO NOT AUTOCOMPLETE US ADDRESSES');
+        expect(res.suggestions[0].primary_line).to.eql('Test Keys Do Not Autocomplete Us Addresses');
+
         return done();
       });
     });

--- a/test/usAutocompletions.js
+++ b/test/usAutocompletions.js
@@ -18,6 +18,22 @@ describe('us_autocompletions', () => {
       });
     });
 
+    it('returns a list of suggestions with custom case', (done) => {
+      Lob.usVerifications.verify({
+        primary_line: 'deliverable',
+        city: 'San Francisco',
+        state: 'CA',
+        zip_code: '94107'
+      }, {
+        case: 'proper'
+      }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res.suggestions).to.exist;
+        expect(res.suggestions[0].primary_line).to.eql('TEST KEYS DO NOT AUTOCOMPLETE US ADDRESSES');
+        return done();
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
We've added a new query param for autocomplete similar to us_verfiications that'll allow users to return addresses in all upper case or proper case