### PR TITLE
fix(resourceBase): Allow for non json returns

### DIFF
--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -93,9 +93,9 @@ class ResourceBase {
           return reject(error);
         }
 
-        if (typeof body === 'string') {
-          return resolve(body);
-        }
+        // if (typeof body === 'string') {
+        //   return resolve(body);
+        // }
         
         Object.defineProperty(body, '_response', {
           enumerable: false,

--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -93,9 +93,9 @@ class ResourceBase {
           return reject(error);
         }
 
-        // if (typeof body === 'string') {
-        //   return resolve(body);
-        // }
+        if (typeof body === 'string') {
+          return resolve(body);
+        }
         
         Object.defineProperty(body, '_response', {
           enumerable: false,

--- a/lib/resources/resourceBase.js
+++ b/lib/resources/resourceBase.js
@@ -93,6 +93,10 @@ class ResourceBase {
           return reject(error);
         }
 
+        if (typeof body === 'string') {
+          return resolve(body);
+        }
+        
         Object.defineProperty(body, '_response', {
           enumerable: false,
           writable: false,


### PR DESCRIPTION
We have several internal endpoints that lob-node-admin is using that don't have json returns(They mostly seem to return strings for html). This should allow for those requests to pass through again