### PR TITLE
PLAT-2193: update deprecated GitHub Actions

### DIFF
--- a/.github/workflows/forked_run_tests.yml
+++ b/.github/workflows/forked_run_tests.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         node: ['12', '14']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
     - name: Create NYC folder

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,14 +17,14 @@ jobs:
     steps:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # use node setup library (more info here https://github.com/actions/setup-node)
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 12
 
       # publishes to NPM using third party tool (more info here https://github.com/JS-DevTools/npm-publish)
-      - uses: JS-DevTools/npm-publish@v1
+      - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         node: ['12', '14', '16', '18']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
     - name: Create NYC folder


### PR DESCRIPTION
## JIRA

* [PLAT-2193](https://lobsters.atlassian.net/browse/PLAT-2193)

## Description

* `actions/checkout@v2`, `actions/setup-node@v2` and `JS-DevTools/npm-publish@v1` run Node 12 or 16 and are deprecated, we need them to run Node 20:

See:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
and
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/