### PR TITLE
BILL-5586: Add descriptor_code support to bank account verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lob",
-  "version": "7.1.0",
+  "version": "8.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lob",
-      "version": "7.1.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Lob.com",
     "printing"
   ],
-  "version": "8.0.0",
+  "version": "8.1.0",
   "homepage": "https://github.com/lob/lob-node",
   "author": "Lob <support@lob.com> (https://lob.com/)",
   "dependencies": {

--- a/test/bankAccounts.js
+++ b/test/bankAccounts.js
@@ -154,8 +154,10 @@ describe('bank accounts', () => {
         .post(`/v1/bank_accounts/${  bankAccountId  }/verify`)
         .reply(200, verifiedBankAccount);
 
-      Lob.bankAccounts.create(BANK_ACCOUNT_INPUT, (_err, res) => {
-        Lob.bankAccounts.verify(res.id, { descriptor_code: 'SM11AA' }, (_err2, res2) => {
+      Lob.bankAccounts.create(BANK_ACCOUNT_INPUT, (err, res) => {
+        if (err) return done(err);
+        Lob.bankAccounts.verify(res.id, { descriptor_code: 'SM11AA' }, (err2, res2) => {
+          if (err2) return done(err2);
           expect(res2).to.have.property('id');
           expect(res2.verified).to.eql(true);
           expect(res2.object).to.eql('bank_account');
@@ -176,6 +178,7 @@ describe('bank accounts', () => {
         .reply(200, fixtures.BANK_ACCOUNT);
 
       Lob.bankAccounts.retrieve(bankAccountId, (err, res) => {
+        if (err) return done(err);
         expect(res).to.have.property('microdeposit_type');
         expect(['amounts', 'descriptor_code']).to.include(res.microdeposit_type);
         return done();
@@ -191,6 +194,7 @@ describe('bank accounts', () => {
         .reply(200, verifiedAccount);
 
       Lob.bankAccounts.retrieve(bankAccountId, (err, res) => {
+        if (err) return done(err);
         expect(res.verified).to.eql(true);
         expect(res.microdeposit_type).to.eql(null);
         return done();

--- a/test/bankAccounts.js
+++ b/test/bankAccounts.js
@@ -117,10 +117,10 @@ describe('bank accounts', () => {
 
   describe('verify', () => {
 
-    it('verifies a bank account', (done) => {
+    it('verifies a bank account with amounts', (done) => {
       const bankAccountId = fixtures.BANK_ACCOUNT.id;
       const amounts = [23, 34];
-      const verifiedBankAccount = fixtures.clone(fixtures.BANK_ACCOUNT, { verified: true });
+      const verifiedBankAccount = fixtures.clone(fixtures.BANK_ACCOUNT, { verified: true, microdeposit_type: null });
 
       mockLob()
         .post('/v1/bank_accounts')
@@ -139,6 +139,61 @@ describe('bank accounts', () => {
           expect(res2.object).to.eql('bank_account');
           return done();
         });
+      });
+    });
+
+    it('verifies a bank account with descriptor_code', (done) => {
+      const bankAccountId = fixtures.BANK_ACCOUNT.id;
+      const verifiedBankAccount = fixtures.clone(fixtures.BANK_ACCOUNT, { verified: true, microdeposit_type: null });
+
+      mockLob()
+        .post('/v1/bank_accounts')
+        .reply(200, fixtures.clone(fixtures.BANK_ACCOUNT, { microdeposit_type: 'descriptor_code' }));
+
+      mockLob()
+        .post(`/v1/bank_accounts/${  bankAccountId  }/verify`)
+        .reply(200, verifiedBankAccount);
+
+      Lob.bankAccounts.create(BANK_ACCOUNT_INPUT, (_err, res) => {
+        Lob.bankAccounts.verify(res.id, { descriptor_code: 'SM11AA' }, (_err2, res2) => {
+          expect(res2).to.have.property('id');
+          expect(res2.verified).to.eql(true);
+          expect(res2.object).to.eql('bank_account');
+          return done();
+        });
+      });
+    });
+
+  });
+
+  describe('microdeposit_type', () => {
+
+    it('exposes microdeposit_type on a retrieved bank account', (done) => {
+      const bankAccountId = fixtures.BANK_ACCOUNT.id;
+
+      mockLob()
+        .get(`/v1/bank_accounts/${  bankAccountId}`)
+        .reply(200, fixtures.BANK_ACCOUNT);
+
+      Lob.bankAccounts.retrieve(bankAccountId, (err, res) => {
+        expect(res).to.have.property('microdeposit_type');
+        expect(['amounts', 'descriptor_code']).to.include(res.microdeposit_type);
+        return done();
+      });
+    });
+
+    it('microdeposit_type is null once verified', (done) => {
+      const bankAccountId = fixtures.BANK_ACCOUNT.id;
+      const verifiedAccount = fixtures.clone(fixtures.BANK_ACCOUNT, { verified: true, microdeposit_type: null });
+
+      mockLob()
+        .get(`/v1/bank_accounts/${  bankAccountId}`)
+        .reply(200, verifiedAccount);
+
+      Lob.bankAccounts.retrieve(bankAccountId, (err, res) => {
+        expect(res.verified).to.eql(true);
+        expect(res.microdeposit_type).to.eql(null);
+        return done();
       });
     });
 

--- a/test/mocks/fixtures.js
+++ b/test/mocks/fixtures.js
@@ -26,6 +26,7 @@ const BANK_ACCOUNT = {
   account_type: 'company',
   signatory: 'John Doe',
   verified: false,
+  microdeposit_type: 'amounts',
   date_created: '2024-01-16T12:00:00.000Z',
   date_modified: '2024-01-16T12:00:00.000Z'
 };


### PR DESCRIPTION
## Description

**Problem:** Stripe's Setup Intents API added a descriptor code-based microdeposit verification path alongside the legacy two-amount path. When a bank account is created via Setup Intents, Stripe sends a single $0.01 deposit whose statement descriptor contains a 6-character code beginning with `SM`. The Node SDK had no test coverage for this path, and the `BANK_ACCOUNT` fixture was missing `microdeposit_type`, so the response shape didn't reflect the real API.

**Solution:** Added `microdeposit_type` to the `BANK_ACCOUNT` fixture and added test coverage for:
- Verifying with `descriptor_code` (new path)
- Verifying with `amounts` (existing path — renamed test for clarity)
- `microdeposit_type` present on a retrieved (unverified) bank account
- `microdeposit_type` is `null` once an account is verified

**Non-breaking:** The Node SDK is a pure pass-through wrapper — `descriptor_code` already routes correctly through `URLSearchParams` with no model-layer changes needed. All existing code using `amounts` continues to work without any changes.

## Story

https://lobsters.atlassian.net/browse/BILL-5586 (subtask of https://lobsters.atlassian.net/browse/BILL-5581)

## Related PR's

Mirrors https://github.com/lob/lob-php/pull/192

## Verify

- [x] Code runs without errors
- [x] Tests pass (97 passing, bankAccounts.js at 100% coverage)